### PR TITLE
default dozor params, fix edit raster params/detector stop buttons

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -793,7 +793,7 @@ def runDozorThread(directory,
     else:
         raise Exception("seqNum seems to be non-standard (<0)")
 
-    comm_s = "ssh -q {} \"cd {};{} -w -bin 2 h5_row_{}.dat\"".format(node,
+    comm_s = "ssh -q {} \"cd {};{} -w -bin 1 h5_row_{}.dat\"".format(node,
                                                                      dozorRowDir,
                                                                      dozorComm,
                                                                      rowIndex)

--- a/h5_template.dat
+++ b/h5_template.dat
@@ -6,7 +6,7 @@ X-ray_wavelength $wavelength
 detector_distance $detector_distance
 orgx $orgx
 orgy $orgy
-pixel_min 4
+pixel_min 2
 first_image_number $first_image_number
 number_images $number_images
 name_template_image $name_template_image

--- a/h5_template.dat
+++ b/h5_template.dat
@@ -6,7 +6,7 @@ X-ray_wavelength $wavelength
 detector_distance $detector_distance
 orgx $orgx
 orgy $orgy
-pixel_min 2
+pixel_min 0
 first_image_number $first_image_number
 number_images $number_images
 name_template_image $name_template_image

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -869,6 +869,19 @@ class ScreenDefaultsDialog(QtWidgets.QDialog):
         self.rasterThreshSigBckrnd.setEnabled(False)
         self.rasterThreshSigStrong.setEnabled(False)                        
 
+    #code below and its application from: https://snorfalorpagus.net/blog/2014/08/09/validating-user-input-in-pyqt4-using-qvalidator/
+    def checkEntryState(self, *args, **kwargs):
+      sender = self.sender()
+      validator = sender.validator()
+      state = validator.validate(sender.text(), 0)[0]
+      if state == QtGui.QValidator.Intermediate:
+          color = '#fff79a' # yellow
+      elif state == QtGui.QValidator.Invalid:
+          color = '#f6989d' # red
+      else:
+          color = '#ffffff' # white
+      sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
+
 
 class PuckDialog(QtWidgets.QDialog):
     def __init__(self, parent = None):
@@ -3335,6 +3348,11 @@ class ControlMain(QtWidgets.QMainWindow):
         values = value['minmax']
         field_name = value['name']
         logger.info('validateFields: %s %s %s' % (field_name, field.text(), values))
+        try:
+          val = float(field.text())
+          logger.info('>= min: %s <= max: %s' % (val >= values['fmx']['min'], val <= values['fmx']['max']))
+        except: #total exposure time is '----' for rasters, so just ignore
+          pass
         if field.text() == '----': #special case: total exp time not calculated for non-standard, non-vector experiments
             continue
         if field.validator().validate(field.text(),0)[0] != QtGui.QValidator.Acceptable:

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -649,7 +649,7 @@ class UserScreenDialog(QFrame):
       
     def stopDetCB(self):
       logger.info('stopping detector')
-      self.parent.stopDet_pv.put(1)
+      self.parent.stopDet_pv.put(0)
 
     def rebootDetIocCB(self):
       logger.info('rebooting detector IOC')


### PR DESCRIPTION
- Dozor re-built on compute nodes (AMX: cpu-019 to cpu-026, FMX: cpu-011 to cpu-015) with horizontal beam stop shadow, tested 24Nov2020 on AMX; default dozor settings work well. Need to bring change for dozor settings over to FMX for continued testing.

- Edit raster params button fix brought from FMX->AMX as mail patch (addresses https://github.com/NSLS-II/lsdc/issues/20)

- Detector stop button works from GUI now.

(In lsdc_amx: Could also fast-forward merge 20201021_sync_dozor_settings with 20201021)