### PR TITLE
Earlier gov transitions and gov status pv checks at end of rasters

### DIFF
--- a/bin/dump_blconfigs.py
+++ b/bin/dump_blconfigs.py
@@ -1,0 +1,44 @@
+import db_lib
+from datetime import date
+import sys
+
+'''
+Script to dump all config parameters for beamlines
+
+Directions: copy or link this file to the top level of LSDC.
+setup the main conda environment such as lsdcServer_2020-1.0.
+LSDC must be in the PYTHONPATH or be local
+python <this script name>
+Output will be files called blconfig_params_{blname}_{date}
+'''
+def getConfigParamsDict(beamline_id):
+    configList = db_lib.getAllBeamlineConfigParams(beamline_id)
+    configDict = {}
+    for config in configList:
+        try:
+            configDict[config['info_name']] = config['info']['val']
+        except KeyError:
+            pass
+    return configDict
+
+def getAllBeamlineConfigParams(beamline_id):
+    configDict = getConfigParamsDict(beamline_id)
+    to_return = ''
+    for name, value in configDict.items():
+       to_return += f'{name} {value}\n'
+    return to_return
+
+def printAllBeamlineConfigParams(beamline_id):
+    print(getAllBeamlineConfigParams(beamline_id))
+
+def logAllBeamlineConfigParams(beamline_id):
+    configDict = getConfigParamsDict(beamline_id)
+    for name, value in configDict.items():
+        logger.info(f'{name} {value}')
+
+if __name__ == '__main__':
+    #printAllBeamlineConfigParams('amx')
+    #sys.exit(0)
+    for beamline_id in ['amx', 'fmx']:
+        with open(f'blconfig_params_{beamline_id}_{date.today().isoformat()}', 'w') as blconfig_out:
+            blconfig_out.write(getAllBeamlineConfigParams(beamline_id))

--- a/bin/run_dump_blconfigs.sh
+++ b/bin/run_dump_blconfigs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+conda activate lsdcServer_2020-1.0
+python dump_blconfigs.py
+mv blconfig* /GPFS/CENTRAL/xf17id1/skinnerProjectsBackup/bnlpx_config/blConfigs

--- a/config_params.py
+++ b/config_params.py
@@ -16,6 +16,7 @@ ISPYB_RESULT_ENTRY_DELAY = 'ispybResultEntryDelay'
 RASTER_LONG_SNAPSHOT_DELAY = 'rasterLongSnapshotDelay'
 RASTER_SHORT_SNAPSHOT_DELAY = 'rasterShortSnapshotDelay'
 RASTER_POST_SNAPSHOT_DELAY = 'rasterPostSnapshotDelay'
+RASTER_GUI_XREC_FILL_DELAY = 'rasterGuiXrecFillDelay'
 
 # governor transition gain/exposure times
 LOW_MAG_GAIN_DA = 'lowMagGainDA'

--- a/daq_lib.py
+++ b/daq_lib.py
@@ -531,7 +531,8 @@ def logMxRequestParams(currentRequest,wait=True):
   visitName = daq_utils.getVisitName()
   try: #I'm worried about unforseen ispyb db errors
     #rasters results are entered in ispyb by the GUI, no need to wait
-    if wait: time.sleep(getBlConfig(ISPYB_RESULT_ENTRY_DELAY))
+    if wait:
+      time.sleep(getBlConfig(ISPYB_RESULT_ENTRY_DELAY))
     currentIspybDCID = ispybLib.insertResult(newResult,"mxExpParams",currentRequest,visitName)
   except Exception as e:
     currentIspybDCID = 999999
@@ -709,7 +710,6 @@ def collectData(currentRequest):
       imagesAttempted = collect_detector_seq_hw(sweep_start,range_degrees,img_width,exposure_period,file_prefix,data_directory_name,file_number_start,currentRequest)
   try:
     if (logMe) and prot == 'raster':
-      
       logMxRequestParams(currentRequest,wait=False)
     elif (logMe):
       logMxRequestParams(currentRequest)

--- a/daq_lib.py
+++ b/daq_lib.py
@@ -498,7 +498,7 @@ def stopDCQueue(flag):
 
 
 
-def logMxRequestParams(currentRequest):
+def logMxRequestParams(currentRequest,wait=True):
   global currentIspybDCID
   reqObj = currentRequest["request_obj"]
   transmissionReadback = getPvDesc("transmissionRBV")
@@ -530,7 +530,8 @@ def logMxRequestParams(currentRequest):
   logfile.close()
   visitName = daq_utils.getVisitName()
   try: #I'm worried about unforseen ispyb db errors
-    time.sleep(getBlConfig(ISPYB_RESULT_ENTRY_DELAY))
+    #rasters results are entered in ispyb by the GUI, no need to wait
+    if wait: time.sleep(getBlConfig(ISPYB_RESULT_ENTRY_DELAY))
     currentIspybDCID = ispybLib.insertResult(newResult,"mxExpParams",currentRequest,visitName)
   except Exception as e:
     currentIspybDCID = 999999
@@ -707,7 +708,10 @@ def collectData(currentRequest):
       beamline_lib.mvaDescriptor("omega",sweep_start)
       imagesAttempted = collect_detector_seq_hw(sweep_start,range_degrees,img_width,exposure_period,file_prefix,data_directory_name,file_number_start,currentRequest)
   try:
-    if (logMe):
+    if (logMe) and prot == 'raster':
+      
+      logMxRequestParams(currentRequest,wait=False)
+    elif (logMe):
       logMxRequestParams(currentRequest)
   except TypeError:
     logger.error("caught type error in logging")

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -3053,7 +3053,10 @@ class ControlMain(QtWidgets.QMainWindow):
         if (rasterDef["status"] == RasterStatus.DRAWN.value):
           self.drawPolyRaster(rasterReq)
         elif (rasterDef["status"] == RasterStatus.READY_FOR_FILL.value):
-          self.fillPolyRaster(rasterReq)
+          self.fillPolyRaster(
+            rasterReq,
+            waitTime=getBlConfig(RASTER_GUI_XREC_FILL_DELAY)
+          )
           logger.info("polyraster filled by displayXrecRaster")
         elif (rasterDef["status"] == RasterStatus.READY_FOR_SNAPSHOT.value):
           if (self.controlEnabled()):          
@@ -3760,8 +3763,8 @@ class ControlMain(QtWidgets.QMainWindow):
       self.send_to_server("mvaDescriptor(\"omega\",0)")
       
 
-    def fillPolyRaster(self,rasterReq): #at this point I should have a drawn polyRaster
-      time.sleep(1)
+    def fillPolyRaster(self,rasterReq,waitTime=1): #at this point I should have a drawn polyRaster
+      time.sleep(waitTime)
       logger.info("filling poly for " + str(rasterReq["uid"]))
       resultCount = len(db_lib.getResultsforRequest(rasterReq["uid"]))
       rasterResults = db_lib.getResultsforRequest(rasterReq["uid"])


### PR DESCRIPTION
### **Order of steps in daq_macros.snakeRasterNormal after data acquisition**  (#36)
 
![new_rasters](https://user-images.githubusercontent.com/61419915/107540672-4ca2c680-6b94-11eb-9f9b-7557524f2498.png)

* Eliminates ispyb images with black background with earlier governor transition
* Timing approximately 3.5-5 seconds depending on tuning of delays
* Timing delays tunable with database parameters