### PR TITLE
add unlatchGov() command for FloCos

### DIFF
--- a/daq_lib.py
+++ b/daq_lib.py
@@ -66,6 +66,10 @@ def destroy_gui_message():
   beamline_support.pvPut(gui_popup_message_string_pv,"killMessage")
 
 
+def unlatchGov(): # Command needed for FloCos to recover robot
+  setPvDesc("robotGovActive",1)
+  logger.info(f"unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
+
 def set_field(param,val):
   var_list[param] = val
   beamline_support.pvPut(var_channel_list[param],val)

--- a/daq_lib.py
+++ b/daq_lib.py
@@ -70,6 +70,7 @@ def unlatchGov(): # Command needed for FloCos to recover robot
   print(f"OLD: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
   logger.info(f"OLD: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
   setPvDesc("robotGovActive",1)
+  time.sleep(0.2)
   print(f"NEW: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
   logger.info(f"NEW: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
 

--- a/daq_lib.py
+++ b/daq_lib.py
@@ -67,8 +67,12 @@ def destroy_gui_message():
 
 
 def unlatchGov(): # Command needed for FloCos to recover robot
+  print(f"OLD: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
+  logger.info(f"OLD: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
   setPvDesc("robotGovActive",1)
-  logger.info(f"unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
+  print(f"NEW: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
+  logger.info(f"NEW: unlatchGov called, gov active state = {getPvDesc('robotGovActive')}")
+
 
 def set_field(param,val):
   var_list[param] = val


### PR DESCRIPTION
A simple command to make the governor active for the FloCos during their recovery procedure. This ensures uniform training and smoother recovery procedures. The changes were added to daq.py. The command is unlatchGov().