### PR TITLE
configure kafka encryption

### DIFF
--- a/kafka_producer.py
+++ b/kafka_producer.py
@@ -4,7 +4,11 @@ import sys
 import json
 from time import sleep
 
-conf = {'bootstrap.servers':os.environ["KAFKA_SERVERS"]}
+import certifi
+
+conf = {'bootstrap.servers':os.environ["KAFKA_SERVERS"]
+        'security.protocol': 'SSL',
+        'ssl.ca.location': certifi.where()}
 p = Producer(**conf)
 
 def delivery_callback(err, msg):

--- a/kafka_producer.py
+++ b/kafka_producer.py
@@ -6,7 +6,7 @@ from time import sleep
 
 import certifi
 
-conf = {'bootstrap.servers':os.environ["KAFKA_SERVERS"]
+conf = {'bootstrap.servers':os.environ["KAFKA_SERVERS"],
         'security.protocol': 'SSL',
         'ssl.ca.location': certifi.where()}
 p = Producer(**conf)


### PR DESCRIPTION
This PR adds the following initialization parameters to Kafka producers and consumers:
```
"security.protocol": "SSL",
"ssl.ca.location": certifi.where()
```