### PR TITLE
Remove matplotlib plots

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -2327,8 +2327,6 @@ def collectSpec(filename,gotoSA=True):
       break
     time.sleep(0.05)
   specArray = getPvDesc("mercurySpectrum")
-  plt.plot(specArray)
-  plt.show(block=False)
   nowtime_s = str(int(time.time()))
   specFileName = filename + "_" + nowtime_s + ".txt"
   specFile = open(specFileName,"w+")
@@ -2345,7 +2343,6 @@ def collectSpec(filename,gotoSA=True):
 
     
 def eScan(energyScanRequest):
-  plt.clf()
   sampleID = energyScanRequest["sample"]
   reqObj = energyScanRequest["request_obj"]
   exptime = reqObj['exposure_time']

--- a/daq_main_common.py
+++ b/daq_main_common.py
@@ -8,7 +8,6 @@ import daq_utils
 import det_lib
 import beamline_support
 import beamline_lib
-from start_bs import plt
 import atexit
 import traceback
 

--- a/start_bs.py
+++ b/start_bs.py
@@ -17,9 +17,6 @@ from bluesky.callbacks.broker import post_run
 from bluesky.callbacks.broker import verify_files_saved
 gs.RE.subscribe('stop', post_run(verify_files_saved))
 """
-# Import matplotlib and put it in interactive mode.
-import matplotlib.pyplot as plt
-plt.ion()
 
 # import nslsii
 


### PR DESCRIPTION
As part of the work to make the server run as a service user for the next cycle to become fully compliant with security requirements, any X-related forwarding like the energy scan plots will be removed. 