### PR TITLE
update FMX annealer to use in and out statuses

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -3570,7 +3570,7 @@ def createProposal(propNum,PI_login="boaty"):
 def topViewCheckOn():
   setBlConfig(TOP_VIEW_CHECK,1)
 
-def anneal(annealTime):
+def anneal(annealTime=1.0):
   if daq_utils.beamline == 'fmx':
     if not govStatusGet('SA'):
       daq_lib.gui_message('Not in Governor state SA, exiting')
@@ -3580,15 +3580,15 @@ def anneal(annealTime):
 
     annealer.air.put(1)
 
-    while not annealer.status.get():
-      logger.info(f'anneal state before annealing: {annealer.status.get()}')
+    while not annealer.inStatus.get():
+      logger.info(f'anneal state before annealing: {annealer.inStatus.get()}')
       time.sleep(0.1)
 
     time.sleep(annealTime)
     annealer.air.put(0)
 
-    while not annealer.status.get():
-      logger.info(f'anneal state after annealing: {annealer.status.get()}')
+    while not annealer.outStatus.get():
+      logger.info(f'anneal state after annealing: {annealer.outStatus.get()}')
       time.sleep(0.1)
 
     govStateSet('SA')

--- a/fmx_annealer.py
+++ b/fmx_annealer.py
@@ -114,9 +114,11 @@ from ophyd import PVPositioner, PVPositionerPC, Device, Component as Cpt, EpicsM
         
 ## DONE Redo ophyd object with proper PV
 class Annealer(Device):
-    air = Cpt(EpicsSignal, 'Air-Sel')
-    status = Cpt(EpicsSignalRO, 'In-Sts') # status: 0 (Not In), 1 (In)
-    
-annealer = Annealer('XF:17IDC-ES:FMX{Wago:1}Annealer', name='annealer',
+    air = Cpt(EpicsSignal, '1}AnnealerAir-Sel')
+    inStatus = Cpt(EpicsSignalRO, '2}AnnealerIn-Sts') # status: 0 (Not In), 1 (In)
+    outStatus = Cpt(EpicsSignalRO, '2}AnnealerOut-Sts') # status: 0 (Not In), 1 (In)
+
+## FMX annealer aka cryo blocker
+annealer = Annealer('XF:17IDC-ES:FMX{Wago:', name='annealer',
                         read_attrs=[],
                         labels=['fmx'])


### PR DESCRIPTION
- annealer IOC updated to provide in and out status PVs, instead of just one status PV
- also add default anneal time
- code has been tested and works as expected