### PR TITLE
Show pucks to be added by staff in chronological order

### DIFF
--- a/db_lib.py
+++ b/db_lib.py
@@ -101,7 +101,7 @@ def createContainer(name, capacity, owner, kind, **kwargs): #16_pin_puck, automo
 def updateContainer(cont_info): #really updating the contents
     cont = cont_info['uid']
     q = {'uid': cont_info.pop('uid', '')}
-    cont_info.pop('time', '')
+    # cont_info.pop('time', '') update time to support ordering by most recent
     container_ref.update(q, {'content':cont_info['content']}) 
 
     return cont

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -950,7 +950,7 @@ class PuckDialog(QtWidgets.QDialog):
 
     def initData(self):
         puckListUnsorted = db_lib.getAllPucks(daq_utils.owner)
-        puckList = sorted(puckListUnsorted,key=lambda i: i['name'],reverse=False)
+        puckList = sorted(puckListUnsorted,key=lambda i: i['time'],reverse=True)
         dewarObj = db_lib.getPrimaryDewar(daq_utils.beamline)
         pucksInDewar = dewarObj['content']
         data = []


### PR DESCRIPTION
* reduce chance of loading incorrect pucks into dewar
* e.g. Puck-001, Puck001 will no longer be next to each other
* most recent batch of loaded pucks will be at top of list
* tested at amx