### PR TITLE
read Kafka producer parameters from a file

### DIFF
--- a/kafka_producer.py
+++ b/kafka_producer.py
@@ -5,10 +5,18 @@ import json
 from time import sleep
 
 import certifi
+import yaml
 
-conf = {'bootstrap.servers':os.environ["KAFKA_SERVERS"],
-        'security.protocol': 'SSL',
+with open("nsls2-kafka-config.yml") as f:
+    kafka_config = yaml.safe_load(f)
+
+bootstrap_servers = ",".join(kafka_config["bootstrap_servers"])
+lsdc_producer_config = kafka_config["lsdc_producer_config"]
+
+conf = {'bootstrap.servers':bootstrap_servers,
         'ssl.ca.location': certifi.where()}
+conf.update(lsdc_producer_config)
+
 p = Producer(**conf)
 
 def delivery_callback(err, msg):


### PR DESCRIPTION
This PR adds code to read Kafka producer parameters from a YAML file.

The intention is for authentication and authorization parameters to be found in the YAML file.

This is an example file:
```
---
  bootstrap_servers:
    - kafka1.nsls2.bnl.gov:9092
    - kafka2.nsls2.bnl.gov:9092
    - kafka3.nsls2.bnl.gov:9092
    - kafka4.nsls2.bnl.gov:9092
    - kafka5.nsls2.bnl.gov:9092
    - kafka6.nsls2.bnl.gov:9092
    - kafka7.nsls2.bnl.gov:9092
  lsdc_producer_config:
    security.protocol: SASL_SSL
    sasl.mechanisms: PLAIN
    sasl.username: beamline
    sasl.password: <password>
```
Any producer configuration parameter can be specified in the `lsdc_producer_config`, but the parameters shown here are required for a producer to connect to the NSLS2 Kafka cluster.