### PR TITLE
Update conda envs for 2022 1

### DIFF
--- a/bin/lsdcGui_amx
+++ b/bin/lsdcGui_amx
@@ -5,4 +5,4 @@ export LSDCHOME=${PROJDIR}lsdc_amx
 export PATH=/usr/local/bin:/usr/bin:/bin
 export PYTHONPATH=".:${CONFIGDIR}:/opt/dectris/albula/4.0/python:${LSDCHOME}"
 source ${CONFIGDIR}daq_env_amx.txt
-/opt/conda_envs/lsdc-gui-2021-1.1/bin/python $LSDCHOME/lsdcGui.py&
+/opt/conda_envs/lsdc-gui-2022-1-latest/bin/python $LSDCHOME/lsdcGui.py&

--- a/bin/lsdcGui_fmx
+++ b/bin/lsdcGui_fmx
@@ -5,4 +5,4 @@ export LSDCHOME=${PROJDIR}lsdc
 export PATH=/usr/local/bin:/usr/bin:/bin
 export PYTHONPATH=".:${CONFIGDIR}:/opt/dectris/albula/4.0/python:${LSDCHOME}"
 source ${CONFIGDIR}daq_env.txt
-/opt/conda_envs/lsdc-gui-2021-1.1/bin/python $LSDCHOME/lsdcGui.py&
+/opt/conda_envs/lsdc-gui-2022-1-latest/bin/python $LSDCHOME/lsdcGui.py&

--- a/bin/lsdcRemote_amx.cmd
+++ b/bin/lsdcRemote_amx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not ideal as environment name also needed by daq_mainAux
-conda activate lsdc-server-2021-1.3
+conda activate lsdc-server-2022-1-latest
 $LSDCHOME/daq_mainAux.py

--- a/bin/lsdcRemote_fmx.cmd
+++ b/bin/lsdcRemote_fmx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not ideal as environment name also needed by daq_mainAux
-conda activate lsdc-server-2021-1.3
+conda activate lsdc-server-2022-1-latest
 $LSDCHOME/daq_mainAux.py

--- a/bin/lsdcServer_amx.cmd
+++ b/bin/lsdcServer_amx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not idea as environment name also needed by daq_main2
-conda activate lsdc-server-2021-1.3
+conda activate lsdc-server-2022-1-latest
 $LSDCHOME/lsdcServer

--- a/bin/lsdcServer_fmx.cmd
+++ b/bin/lsdcServer_fmx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not idea as environment name also needed by daq_main2
-conda activate lsdc-server-2021-1.3
+conda activate lsdc-server-2022-1-latest
 $LSDCHOME/lsdcServer

--- a/daq_main2.py
+++ b/daq_main2.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2021-1.3/bin/ipython -i
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/ipython -i
 """
 The main server for the LSDC system
 """

--- a/daq_mainAux.py
+++ b/daq_mainAux.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2021-1.3/bin/ipython -i
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/ipython -i
 """
 The server run when lsdcRemote is used
 """

--- a/mountCounter.py
+++ b/mountCounter.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc_dev/bin/python
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/python
 import lsdb1
 import sys
 

--- a/runFastDPH5.py
+++ b/runFastDPH5.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdcServer_2020-1.0/bin/python
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/python
 import os
 import sys
 import db_lib

--- a/runPinAlign.py
+++ b/runPinAlign.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/collection-2018-1.0/bin/python
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/python
 import sys
 import os
 

--- a/runSpotFinder4syncW.py
+++ b/runSpotFinder4syncW.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdcServer_2020-1.0/bin/python
+#!/opt/conda_envs/lsdc-server-2022-1-latest/bin/python
 import time
 import os
 import sys


### PR DESCRIPTION
Point to conda environments created for 2022-1 cycle 1. For both the server and gui envs, we have a symbolic link to -latest so that any updates and fixes to the environments don't require changing all references to specific environments.

Example: lsdc-server-2022-1.0 is a particular environment

- lsdc-server-2022-1-latest is the symbolic link to the current latest environment and used in LSDC code
- An environment lsdc-server-2022-1.1 can be created, and the -latest can be pointed to this new one, while the LSDC code does not need to be modified 