### PR TITLE
Add nyx attenuator 160

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -2861,7 +2861,7 @@ def dna_execute_collection3(dna_startIgnore,dna_range,dna_number_of_images,dna_e
   return 1
 
 def setTrans(transmission): #where transmission = 0.0-1.0
-  if (daq_utils.beamline == "fmx"):  
+  if (daq_utils.beamline in ["fmx", "nyx"]):  
     if (getBlConfig("attenType") == "RI"):
       setPvDesc("RIattenEnergySP",beamline_lib.motorPosFromDescriptor("energy"))
       setPvDesc("RI_Atten_SP",transmission)      

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -2875,8 +2875,9 @@ def setTrans(transmission): #where transmission = 0.0-1.0
     setPvDesc("transmissionSet",transmission)
     setPvDesc("transmissionGo",1)
   time.sleep(0.5)
-  while (not getPvDesc("transmissionDone")):
-    time.sleep(0.1)
+  if daq_utils.beamline != "nyx":  # transmissionDone not available on NYX
+    while (not getPvDesc("transmissionDone")):
+      time.sleep(0.1)
   
   
   

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -3643,8 +3643,12 @@ class ControlMain(QtWidgets.QMainWindow):
       
 
     def setTransCB(self):
-      if (float(self.transmission_ledit.text()) > 1.0 or float(self.transmission_ledit.text()) < 0.001):
-        self.popupServerMessage("Transmission must be 0.001-1.0")
+      try:
+        if (float(self.transmission_ledit.text()) > 1.0 or float(self.transmission_ledit.text()) < 0.001):
+          self.popupServerMessage("Transmission must be 0.001-1.0")
+          return
+      except ValueError as e:
+        self.popupServerMessage("Please enter a valid number")
         return
       comm_s = "setTrans(" + str(self.transmission_ledit.text()) + ")"
       logger.info(comm_s)

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -1881,7 +1881,7 @@ class ControlMain(QtWidgets.QMainWindow):
         hBoxColParams25.addWidget(sampleLifetimeLabel)
         hBoxColParams25.addWidget(self.sampleLifetimeReadback_ledit)
         hBoxColParams22 = QtWidgets.QHBoxLayout()
-        if (daq_utils.beamline == "fmx"):
+        if (daq_utils.beamline in ("fmx", "nyx")):
           if (getBlConfig("attenType") == "RI"):
             self.transmissionReadback = QtEpicsPVLabel(daq_utils.pvLookupDict["RI_Atten_SP"],self,60,3)
             self.transmissionSetPoint = QtEpicsPVEntry(daq_utils.pvLookupDict["RI_Atten_SP"],self,60,3)


### PR DESCRIPTION
modify daq_macros and GUI to allow RI code to be run for NYX as well.

the check for transmissionDone in daq_macros is not used as this is not implemented on NYX.

fix a bug that crashed the GUI while testing this fix, handle non-numbers in the transmission box gradefully