### PR TITLE
Fmx changes to master

### DIFF
--- a/daq_lib.py
+++ b/daq_lib.py
@@ -346,7 +346,7 @@ def mountSample(sampID):
   currentMountedSampleID = mountedSampleDict["sampleID"]
   if (getBlConfig(TOP_VIEW_CHECK) == 1):
     logger.info("setting work pos")
-    if daq_utils.beamline == "fmx":
+    if daq_utils.beamline == "fmx" and getPvDesc('robotSaActive'):
       beamline_lib.mvaDescriptor("sampleX", getPvDesc("robotXMountPos"))
       beamline_lib.mvaDescriptor("sampleY", getPvDesc("robotYMountPos"))
       beamline_lib.mvaDescriptor("sampleZ", getPvDesc("robotZMountPos"))

--- a/daq_utils.py
+++ b/daq_utils.py
@@ -295,20 +295,26 @@ def readPVDesc():
     counter_inf = line.split()
     counter_dict[counter_inf[1]] = beamline_designation + counter_inf[0]    
 
+def createVisitNameRaw(proposalName, maxNumber=None):
+  if maxNumber:
+    number = maxNumber + 1
+  else:
+    number = 1
+  return f'mx{proposalName}-{number}', number
 
-def setProposalID(proposalID,createVisit=True):
-  if (getProposalID() != proposalID): #proposalID changed - create a new visit.
-    logger.info("you changed proposals! " + str(proposalID))
-    try:
-      if (createVisit):
-        visitName = ispybLib.createVisit(proposalID)
-        db_lib.setBeamlineConfigParam(beamline,"proposal",proposalID)                
-      else:
-        visitName, visitNum = ispybLib.createVisitName(proposalID)
-    except Exception as e:
-      visitName = "999999-1234"
-      logger.error("ispyb error in set proposal. Error: %s" % e)
-    setVisitName(visitName)
+def createVisitName(proposalName, maxNumber=None):
+  return createVisitNameRaw(proposalName, maxNumber)
+
+def setProposalID(proposalID,createVisit=True):  # TODO JA proposalID implies a database ID, which it is not (just proposal number). Misleading
+   if (getProposalID() != proposalID): #proposalID changed - create a new visit.
+     logger.info("you changed proposals! " + str(proposalID))
+     logger.info('ignoring createVisit for now - ISPyB required to properly account for visit numbers')
+     try:
+       visitName, visitNum = createVisitName(proposalID)
+       db_lib.setBeamlineConfigParam(beamline,"proposal",proposalID)                
+     except Exception as e:
+       visitName = "999999-1234"
+       logger.error("error in set proposal. Error: %s" % e)
 
 def getProposalID():
   return getBlConfig("proposal")

--- a/db_lib.py
+++ b/db_lib.py
@@ -101,7 +101,7 @@ def createContainer(name, capacity, owner, kind, **kwargs): #16_pin_puck, automo
 def updateContainer(cont_info): #really updating the contents
     cont = cont_info['uid']
     q = {'uid': cont_info.pop('uid', '')}
-    # cont_info.pop('time', '') update time to support ordering by most recent
+    cont_info.pop('time', '')
     container_ref.update(q, {'content':cont_info['content']}) 
 
     return cont

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -950,7 +950,7 @@ class PuckDialog(QtWidgets.QDialog):
 
     def initData(self):
         puckListUnsorted = db_lib.getAllPucks(daq_utils.owner)
-        puckList = sorted(puckListUnsorted,key=lambda i: i['time'],reverse=True)
+        puckList = sorted(puckListUnsorted,key=lambda i: i['name'],reverse=False)
         dewarObj = db_lib.getPrimaryDewar(daq_utils.beamline)
         pucksInDewar = dewarObj['content']
         data = []

--- a/lsdcServer
+++ b/lsdcServer
@@ -1,2 +1,2 @@
-sudo /usr/local/bin/kill_daq
+dzdo /usr/local/bin/kill_daq
 $LSDCHOME/daq_main2.py

--- a/lsdcServer
+++ b/lsdcServer
@@ -1,2 +1,2 @@
-dzdo /usr/local/bin/kill_daq
+dzdo pkill -KILL -f daq_main2.py
 $LSDCHOME/daq_main2.py


### PR DESCRIPTION
Set of changes currently on FMX that need to be brought into master. Changes only on AMX will also need to be reconciled before the release is made later in the week.

- modifications to use dzdo pkill to kill old LSDC server processes started by other beamline staff
- undo puck ordering attempts that were not successful
- fixed a hard-to-find problem where "not in SE" exceptions would pop up in particular situations
- while ISPyB is down, simplify visit numbering scheme by only allowing 1 (normally calculated by looking at existing visits in ISPyB)