### PR TITLE
Fixed crashes in puck and dewar position dialog boxes

### DIFF
--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -1058,7 +1058,10 @@ class PuckDialog(QtWidgets.QDialog):
     def getPuckName(parent = None):
         dialog = PuckDialog(parent)
         result = dialog.exec_()
-        return (dialog.puckName, result == QDialog.Accepted)
+        if hasattr(dialog, 'puckName'):
+            return (dialog.puckName, result == QDialog.Accepted)
+        else:
+            return None, False
 
 
 class DewarDialog(QtWidgets.QDialog):
@@ -1133,8 +1136,10 @@ class DewarDialog(QtWidgets.QDialog):
     def getDewarPos(parent = None,action="add"):
         dialog = DewarDialog(parent,action)
         result = dialog.exec_()
-        return (dialog.dewarPos, result == QDialog.Accepted)
-
+        if hasattr(dialog, 'dewarPos'):
+            return (dialog.dewarPos, result == QDialog.Accepted)
+        else:
+            return None, False
 
 class DewarTree(QtWidgets.QTreeView):
     def __init__(self, parent=None):
@@ -4782,8 +4787,8 @@ class ControlMain(QtWidgets.QMainWindow):
         puckName, ok = PuckDialog.getPuckName()
         if (ok):
           dewarPos, ok = DewarDialog.getDewarPos(parent=self,action="add")
-          ipos = int(dewarPos)+1
           if (ok):
+            ipos = int(dewarPos)+1
             db_lib.insertIntoContainer(daq_utils.primaryDewarName,daq_utils.beamline,ipos,db_lib.getContainerIDbyName(puckName,daq_utils.owner))
             self.treeChanged_pv.put(1)
         else:

--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -998,6 +998,7 @@ class PuckDialog(QtWidgets.QDialog):
         self.proxyModel = QtCore.QSortFilterProxyModel(self)
         labels = QStringList(("Name"))
         self.model.setHorizontalHeaderLabels(labels)
+        self.puckName = None
         for puck in puckList:
           if puck['uid'] not in pucksInDewar:
             item = QtGui.QStandardItem(puck["name"])
@@ -1058,10 +1059,7 @@ class PuckDialog(QtWidgets.QDialog):
     def getPuckName(parent = None):
         dialog = PuckDialog(parent)
         result = dialog.exec_()
-        if hasattr(dialog, 'puckName'):
-            return (dialog.puckName, result == QDialog.Accepted)
-        else:
-            return None, False
+        return (dialog.puckName, result == QDialog.Accepted)
 
 
 class DewarDialog(QtWidgets.QDialog):
@@ -1079,6 +1077,7 @@ class DewarDialog(QtWidgets.QDialog):
       dewarObj = db_lib.getPrimaryDewar(daq_utils.beamline)
       puckLocs = dewarObj['content']
       self.data = []
+      self.dewarPos = None
       for i in range(len(puckLocs)):
         if (puckLocs[i] != ""):
           owner = db_lib.getContainerByID(puckLocs[i])["owner"]
@@ -1136,10 +1135,7 @@ class DewarDialog(QtWidgets.QDialog):
     def getDewarPos(parent = None,action="add"):
         dialog = DewarDialog(parent,action)
         result = dialog.exec_()
-        if hasattr(dialog, 'dewarPos'):
-            return (dialog.dewarPos, result == QDialog.Accepted)
-        else:
-            return None, False
+        return (dialog.dewarPos, result == QDialog.Accepted)
 
 class DewarTree(QtWidgets.QTreeView):
     def __init__(self, parent=None):
@@ -4787,7 +4783,7 @@ class ControlMain(QtWidgets.QMainWindow):
         puckName, ok = PuckDialog.getPuckName()
         if (ok):
           dewarPos, ok = DewarDialog.getDewarPos(parent=self,action="add")
-          if (ok):
+          if ok and dewarPos is not None and puckName is not None:
             ipos = int(dewarPos)+1
             db_lib.insertIntoContainer(daq_utils.primaryDewarName,daq_utils.beamline,ipos,db_lib.getContainerIDbyName(puckName,daq_utils.owner))
             self.treeChanged_pv.put(1)


### PR DESCRIPTION
When Puck selection and Dewar position selection dialog boxes are closed using the 'x' (Close window) button without selecting a puck or position respectively, the GUI crashes.

Fix includes checking whether the accessed attribute exists, if it does return the value else return None.