### PR TITLE
Added health checks during start up

### DIFF
--- a/lsdcGui.py
+++ b/lsdcGui.py
@@ -40,6 +40,8 @@ import _thread #TODO python document suggests using threading! make this chance 
 import lsdcOlog
 from threads import VideoThread
 import socket
+from utils.healthcheck import perform_checks
+
 hostname = socket.gethostname()
 ws_split = hostname.split('ws')
 logging_file = 'lsdcGuiLog.txt'
@@ -5467,42 +5469,17 @@ def get_request_object_escan(reqObj, symbol, runNum, file_prefix, base_path, sam
     return reqObj
 
 def main():
+    logger.info('Starting LSDC...')
+    perform_checks()
     daq_utils.init_environment()
-    daq_utils.readPVDesc()    
+    daq_utils.readPVDesc()
     app = QtWidgets.QApplication(sys.argv)
     ex = ControlMain()
     sys.exit(app.exec_())
 
 #skinner - I think Matt did a lot of what's below and I have no idea what it is. 
 if __name__ == '__main__':
-    if '-pc' in sys.argv or '-p' in sys.argv:
-        logger.info('cProfile not working yet :(')
-        #print 'starting cProfile profiler...'
-        #import cProfile, pstats, io
-        #pr = cProfile.Profile()
-        #pr.enable()
-
-    elif '-py' in sys.argv:
-        logger.info('starting yappi profiler...')
-        import yappi
-        yappi.start(True)
-
     try:
-        main()    
-
-    finally:
-        if '-pc' in sys.argv or '-p' in sys.argv:
-            pass
-            #pr.disable()
-            #s = StringIO()
-            #sortby = 'cumulative'
-            #ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
-            #ps.print_stats()  # dies here, expected unicode, got string, need unicode io stream?
-            #logger.info(s.getvalue())
-
-        elif '-py' in sys.argv:
-            # stop profiler and print results
-            yappi.stop()
-            yappi.get_func_stats().print_all()
-            yappi.get_thread_stats().print_all()
-            logger.info('memory usage: {0}'.format(yappi.get_mem_usage()))
+        main()
+    except Exception as e:
+        logger.error(f'Exception occured: {e}')    

--- a/utils/healthcheck.py
+++ b/utils/healthcheck.py
@@ -49,7 +49,7 @@ def start():
 def check_working_directory():
     working_dir = Path.cwd()
     home_dir = Path.home()
-    if home_dir in working_dir.parents:
+    if home_dir in working_dir.parents or home_dir == working_dir:
         return False
     else:
         return True

--- a/utils/healthcheck.py
+++ b/utils/healthcheck.py
@@ -72,7 +72,10 @@ def handle_fail(check):
     check.passed = False
     logger.error(f'Check {check.name} failed')
     if check.fatal:
+        print("End checks")
+        print(u'\u2500' * 20)
         sys.exit('Fatal error, exiting...')
+        
 
 def perform_checks():
     """Call this function to contruct a DAG where each node is evaluated using 
@@ -83,7 +86,8 @@ def perform_checks():
     for c in [check_working_directory, check_db]:
         for d in c.depends:
             checks.add_edge(d, c)
-
+    print(u'\u2500' * 20)
+    print("Begin checks")
     for check in bfs_tree(checks, start):
         try:
             if all([parent.passed for parent in checks.predecessors(check)]):
@@ -96,4 +100,6 @@ def perform_checks():
             print(f'Exception: {e}')
             logger.error(f'Exception during checks {e}')
             handle_fail(check)
-            
+    print("End checks")
+    print(u'\u2500' * 20)
+    

--- a/utils/healthcheck.py
+++ b/utils/healthcheck.py
@@ -1,0 +1,99 @@
+import sys
+import logging
+from pathlib import Path
+from networkx import DiGraph, bfs_tree
+
+
+logger = logging.getLogger()
+class bcolors:
+    """Class to add colors to output text"""
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+
+def healthcheck(name:str='', 
+                remediation: str='',
+                fatal=False,
+                depends=None):
+    """Decorator added to functions that checks the health of the system, ideally before
+    running the LSDC code
+    """
+    def dec(f):
+        f.name = name
+        f.remediation = remediation
+        f.fatal = fatal
+        f.passed = True
+        f.depends = depends if depends is not None else [start]
+        return f
+    return dec
+
+# Add check functions with the above decorator here...
+@healthcheck(name='start', depends=())
+def start():
+    return True
+
+
+@healthcheck(
+    name='working directory',
+    remediation='Please start LSDC from a data directory, not home directory',
+    fatal=True
+)
+def check_working_directory():
+    working_dir = Path.cwd()
+    home_dir = Path.home()
+    if home_dir in working_dir.parents:
+        return False
+    else:
+        return True
+
+@healthcheck(
+    name='database lib',
+    remediation='Please check if mongo database and servers are running',
+    fatal=False
+)
+def check_db():
+    import db_lib
+    return True
+
+
+def handle_fail(check):
+    """Function to handle a failed check
+    """
+    print(f'{bcolors.FAIL}Fail{bcolors.ENDC}')
+    print(f'{bcolors.WARNING}{bcolors.BOLD}{check.remediation}{bcolors.ENDC}')
+    check.passed = False
+    logger.error(f'Check {check.name} failed')
+    if check.fatal:
+        sys.exit('Fatal error, exiting...')
+
+def perform_checks():
+    """Call this function to contruct a DAG where each node is evaluated using 
+    breadth first search. DAGs allow certain tests to be run only after passing 
+    specific tests. For example
+    """
+    checks = DiGraph()
+    for c in [check_working_directory, check_db]:
+        for d in c.depends:
+            checks.add_edge(d, c)
+
+    for check in bfs_tree(checks, start):
+        try:
+            if all([parent.passed for parent in checks.predecessors(check)]):
+                print(f'Checking {check.name}...', end='\t')
+                if check():
+                    print(f'{bcolors.OKGREEN}Success{bcolors.ENDC}')
+                else:
+                    handle_fail(check)
+        except Exception as e:
+            print(f'Exception: {e}')
+            logger.error(f'Exception during checks {e}')
+            handle_fail(check)
+            


### PR DESCRIPTION
The purpose of this PR is to provide some basic checks during lsdcGui start up. These checks can be easily extended and added to lsdcServer start up. All checks (pass or fail) are shown in the terminal output, failed checks are also logged. Hopefully this will provide enough info to troubleshoot most common issues and scientists can ask for more meaningful assistance from staff.

Currently, it implements a check requested by beam line scientists to prevent starting the GUI in the home folder. Another function checks if db_lib is imported correctly, which tries to connect to the different services such as amostra, conftrak and analysisstore. Other suggestions for checks are welcome. 

Dependencies for checks can also be added, for example, a check for whether the mongo db is up depends on if web services are checked first. Dependency graph is based on suggestions given by the DUTC folks during python training. 