### PR TITLE
Fix raster 2022 11

### DIFF
--- a/bin/lsdcRemote_amx.cmd
+++ b/bin/lsdcRemote_amx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not ideal as environment name also needed by daq_mainAux
-conda activate lsdc-server-2022-2.3
+conda activate lsdc-server-2022-3.2
 $LSDCHOME/daq_mainAux.py

--- a/bin/lsdcRemote_fmx.cmd
+++ b/bin/lsdcRemote_fmx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}mx-processing/
 # below not ideal as environment name also needed by daq_mainAux
-conda activate lsdc-server-2022-2.3
+conda activate lsdc-server-2022-3.2
 $LSDCHOME/daq_mainAux.py

--- a/bin/lsdcServer_amx.cmd
+++ b/bin/lsdcServer_amx.cmd
@@ -10,5 +10,5 @@ export LD_LIBRARY_PATH=$matlab_distrib/bin/glnx86:$matlab_distrib/toolbox
 export PINALIGNDIR=${PROJDIR}pinAlign/pin_align-master/
 export MXPROCESSINGSCRIPTSDIR=${PROJDIR}lsdc-processing/
 # below not idea as environment name also needed by daq_main2
-conda activate lsdc-server-2022-3.2
+conda activate lsdc-server-2022-4.0
 $LSDCHOME/lsdcServer

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -3434,7 +3434,7 @@ def zebraDaqRasterBluesky(flyer, angle_start, num_images, scanWidth, imgWidth, e
                    x_end_um=x_vec_end, y_end_um=y_vec_end, z_end_um=z_vec_end, \
                    file_prefix=filePrefix, data_directory_name=data_directory_name,\
                    detector_dead_time=detectorDeadTime, scan_encoder=scanEncoder, change_state=changeState,\
-                   row_index=row_index, transmission=1)
+                   row_index=row_index, transmission=1, protocol="raster")
     yield from bp.fly([raster_flyer])
 
     logger.info("vector Done")

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1812,7 +1812,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
     if (daq_utils.beamline == "fmx"):
       setPvDesc("sampleProtect",0)
     setPvDesc("vectorGo", 0) #set to 0 to allow easier camonitoring vectorGo
-    daq_lib.setRobotGovState("DA")    
+    gov_lib.setRobotGov(gov_robot, "DA")
     data_directory_name, filePrefix, file_number_start, dataFilePrefix, exptimePerCell, img_width_per_cell, wave, detDist, rasterDef, stepsize, omega, rasterStartX, rasterStartY, rasterStartZ, omegaRad, rowCount, numsteps, totalImages, rows = params_from_raster_req_id(rasterReqID)
     rasterRowResultsList = [{} for i in range(0,rowCount)]    
     processedRasterRowCount = 0

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1848,6 +1848,8 @@ def snakeRasterBluesky(rasterReqID, grain=""):
         vector = {'x': (xMotAbsoluteMove, xEnd), 'y': (yMotAbsoluteMove, yEnd), 'z': (zMotAbsoluteMove, zEnd)}
         yield from zebraDaqRasterBluesky(raster_flyer, omega, numsteps, img_width_per_cell * numsteps, img_width_per_cell, exptimePerCell, rasterFilePrefix,
             data_directory_name, file_number_start, row_index, vector)
+        raster_flyer.zebra.reset.put(1)  # reset after every row to make sure it is clear for the next row
+        time.sleep(0.2)
         # processing
         if (procFlag):    
           if (daq_utils.detector_id == "EIGER-16"):

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1930,6 +1930,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
       daq_lib.set_field("xrecRasterFlag",rasterRequest["uid"])
       logger.info(f'setting xrecRasterFlag to: {rasterRequest["uid"]}')
     raster_flyer.detector.cam.acquire.put(0)
+    raster_flyer.detector.super_unstage()
     logger.info('stopping detector')
 
     """change request status so that GUI only takes a snapshot of

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1850,7 +1850,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
         yield from zebraDaqRasterBluesky(raster_flyer, omega, numsteps, img_width_per_cell * numsteps, img_width_per_cell, exptimePerCell, rasterFilePrefix,
             data_directory_name, file_number_start, row_index, vector)
         raster_flyer.zebra.reset.put(1)  # reset after every row to make sure it is clear for the next row
-        time.sleep(0.2)
+        time.sleep(0.2)  # necessary for reliable row processing - see comment in commit 6793f4
         # processing
         if (procFlag):    
           if (daq_utils.detector_id == "EIGER-16"):

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1812,7 +1812,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
     if (daq_utils.beamline == "fmx"):
       setPvDesc("sampleProtect",0)
     setPvDesc("vectorGo", 0) #set to 0 to allow easier camonitoring vectorGo
-    gov_lib.setRobotGov(gov_robot, "DA")
+    gov_lib.setGovRobot(gov_robot, "DA")
     data_directory_name, filePrefix, file_number_start, dataFilePrefix, exptimePerCell, img_width_per_cell, wave, detDist, rasterDef, stepsize, omega, rasterStartX, rasterStartY, rasterStartZ, omegaRad, rowCount, numsteps, totalImages, rows = params_from_raster_req_id(rasterReqID)
     rasterRowResultsList = [{} for i in range(0,rowCount)]    
     processedRasterRowCount = 0

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1866,6 +1866,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
           spotFindThread.start()
           spotFindThreadList.append(spotFindThread)
         send_kafka_message(f'{daq_utils.beamline}.lsdc.documents', event='event', uuid=rasterReqID, protocol="raster", row=row_index, proc_flag=procFlag)
+        logger.info('row complete')
     """governor transitions:
     initiate transitions here allows for GUI sample/heat map image to update
     after moving to known position"""

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1847,7 +1847,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
         xMotAbsoluteMove, xEnd, yMotAbsoluteMove, yEnd, zMotAbsoluteMove, zEnd = raster_positions(row, stepsize, omegaRad, rasterStartX, rasterStartY, rasterStartZ, row_index)
         vector = {'x': (xMotAbsoluteMove, xEnd), 'y': (yMotAbsoluteMove, yEnd), 'z': (zMotAbsoluteMove, zEnd)}
         yield from zebraDaqRasterBluesky(raster_flyer, omega, numsteps, img_width_per_cell * numsteps, img_width_per_cell, exptimePerCell, rasterFilePrefix,
-            data_directory_name, file_number_start, vector)
+            data_directory_name, file_number_start, row_index, vector)
         # processing
         if (procFlag):    
           if (daq_utils.detector_id == "EIGER-16"):
@@ -3403,7 +3403,7 @@ def zebraDaqBluesky(flyer, angle_start, num_images, scanWidth, imgWidth, exposur
     flyer.detector.cam.acquire.put(0, wait=True)
     logger.info("zebraDaq Done")
 
-def zebraDaqRasterBluesky(flyer, angle_start, num_images, scanWidth, imgWidth, exposurePeriodPerImage, filePrefix, data_directory_name, file_number_start, vector, scanEncoder=3, changeState=True):  # TODO should be raster flyer
+def zebraDaqRasterBluesky(flyer, angle_start, num_images, scanWidth, imgWidth, exposurePeriodPerImage, filePrefix, data_directory_name, file_number_start, row_index, vector, scanEncoder=3, changeState=True):  # TODO should be raster flyer
 
     logger.info("in Zebra Daq Raster Bluesky #1")
     logger.info(f" with vector: {vector}")
@@ -3433,7 +3433,8 @@ def zebraDaqRasterBluesky(flyer, angle_start, num_images, scanWidth, imgWidth, e
                    x_start_um=x_vec_start, y_start_um=y_vec_start, z_start_um=z_vec_start, \
                    x_end_um=x_vec_end, y_end_um=y_vec_end, z_end_um=z_vec_end, \
                    file_prefix=filePrefix, data_directory_name=data_directory_name,\
-                   detector_dead_time=detectorDeadTime, scan_encoder=scanEncoder, change_state=changeState, transmission=1)
+                   detector_dead_time=detectorDeadTime, scan_encoder=scanEncoder, change_state=changeState,\
+                   row_index=row_index, transmission=1)
     yield from bp.fly([raster_flyer])
 
     logger.info("vector Done")

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1928,7 +1928,7 @@ def snakeRasterBluesky(rasterReqID, grain=""):
       db_lib.updateRequest(rasterRequest)
       daq_lib.set_field("xrecRasterFlag",rasterRequest["uid"])
       logger.info(f'setting xrecRasterFlag to: {rasterRequest["uid"]}')
-    #yield from raster_flyer.detector.collect()
+    raster_flyer.detector.cam.acquire.put(0)
     logger.info('stopping detector')
 
     """change request status so that GUI only takes a snapshot of

--- a/daq_macros.py
+++ b/daq_macros.py
@@ -1835,7 +1835,8 @@ def snakeRasterBluesky(rasterReqID, grain=""):
 
     rasterFilePrefix = dataFilePrefix + "_Raster"
     total_exposure_time = exptimePerCell*totalImages
- 
+
+    raster_flyer.configure_detector(file_prefix=rasterFilePrefix, data_directory_name=data_directory_name)
     raster_flyer.detector_arm(angle_start=omega, img_width=img_width_per_cell, total_num_images=totalImages, exposure_period_per_image=exptimePerCell, file_prefix=rasterFilePrefix,
                        data_directory_name=data_directory_name, file_number_start=file_number_start, x_beam=xbeam, y_beam=ybeam, wavelength=wave, det_distance_m=detDist,
                        num_images_per_file=numsteps)

--- a/daq_main2.py
+++ b/daq_main2.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/ipython -i
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/ipython -i
 """
 The main server for the LSDC system
 """

--- a/daq_mainAux.py
+++ b/daq_mainAux.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/ipython -i
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/ipython -i
 """
 The server run when lsdcRemote is used
 """

--- a/lsdcServer
+++ b/lsdcServer
@@ -1,3 +1,3 @@
 dzdo pkill -KILL -f daq_main2.py
-source /opt/conda_envs/lsdc-server-2022-3.2/bin/activate
+source /opt/conda_envs/lsdc-server-2022-4.0/bin/activate
 $LSDCHOME/daq_main2.py

--- a/mountCounter.py
+++ b/mountCounter.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/python
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/python
 import lsdb1
 import sys
 

--- a/runFastDPH5.py
+++ b/runFastDPH5.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/python
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/python
 import os
 import sys
 import db_lib

--- a/runPinAlign.py
+++ b/runPinAlign.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/python
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/python
 import sys
 import os
 

--- a/runSpotFinder4syncW.py
+++ b/runSpotFinder4syncW.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/python
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/python
 import time
 import os
 import sys

--- a/start_bs.py
+++ b/start_bs.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/ipython -i
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/ipython -i
 # import asyncio
 from ophyd import *
 from ophyd.mca import (Mercury1, SoftDXPTrigger)

--- a/sweepDump.py
+++ b/sweepDump.py
@@ -1,4 +1,4 @@
-#!/opt/conda_envs/lsdc-server-2022-3.2/bin/python
+#!/opt/conda_envs/lsdc-server-2022-4.0/bin/python
 import lsdb1
 import sys
 


### PR DESCRIPTION
various fixes necessary to get raster working to a reasonable extent. Note that rastering still has issues when changing exposure time for unknown reasons.

- unstaging detector correctly
- stop detector at end of collection
- send row index and protocol so only first row uses full zebra setup
- move detector configuration before arming
- use lsdc-server-2022-4.0 - contains most fixes to mxtools (but not all)