### PR TITLE
Check data before running fastdp

### DIFF
--- a/albulaUtils.py
+++ b/albulaUtils.py
@@ -108,6 +108,8 @@ def validate_master_HDF5_file(filename):
   Validate master HDF5 by checking if data files exist and can be read
   """
   path = Path(filename)
+  if not path.exists():
+    return False
   try:
     if 'master' in path.stem and path.suffix == '.h5':
       with h5py.File(path) as f:

--- a/daq_lib.py
+++ b/daq_lib.py
@@ -17,6 +17,7 @@ from daq_utils import getBlConfig
 from config_params import *
 from kafka_producer import send_kafka_message
 import logging
+import albulaUtils
 logger = logging.getLogger(__name__)
 
 try:
@@ -731,6 +732,15 @@ def collectData(currentRequest):
     comm_s = os.environ["LSDCHOME"] + "/runSpotFinder4syncW.py " + data_directory_name + " " + file_prefix + " " + str(currentRequest["uid"]) + " " + str(seqNum) + " " + str(currentIspybDCID)+ "&"
     logger.info(comm_s)
     os.system(comm_s)    
+    filename = f"{data_directory_name}/{file_prefix}_{seqNum}_master.h5"
+    logger.info(f"Checking integrity of {filename}")
+    timeout_index = 0
+    while not albulaUtils.validate_master_HDF5_file(filename):
+      timeout_index += 1
+      time.sleep(3)
+      if timeout_index > 15:
+        logger.error(f"Unable to verify master file after {timeout_index} tries, not proceeding with processing")
+        return
     if img_width > 0: #no dataset processing in stills mode
       if (reqObj["fastDP"]):
         if (reqObj["fastEP"]):


### PR DESCRIPTION
use albulaUtils HDF5 routine to check validity of data before running fastDP

- also check for file existence to prevent exceptions downstream within h5py if the file does not exist