### PR TITLE
Service user 2023 1

### DIFF
--- a/config_params.py
+++ b/config_params.py
@@ -76,3 +76,5 @@ GOVERNOR_TIMEOUT = 120  # seconds for a governor move
 
 DEWAR_SECTORS = {'amx':8, 'fmx':8, 'nyx':5}
 PUCKS_PER_DEWAR_SECTOR = {'amx':3, 'fmx':3, 'nyx':3}
+
+LSDC_SERVICE_USERS = ("lsdc-amx", "lsdc-fmx", "lsdc-nyx")

--- a/daq_main2.py
+++ b/daq_main2.py
@@ -12,6 +12,7 @@ from daq_lib import *
 from robot_lib import *
 from beamline_lib import *
 from gov_lib import setGovRobot
+import getpass
 
 import logging
 from logging import handlers
@@ -27,6 +28,13 @@ handler2.setFormatter(myformat)
 logger.addHandler(handler1)
 logger.addHandler(handler2)
 
+if not getpass.getuser().startswith("lsdc-"):
+    message = "LSDC server not being started by a LSDC service user account, aborting!"
+    print(message)
+    logger.error(message)
+    sys.exit(1)
+else:
+    print(f"continuing as we are using a service user: {getpass.getuser()}")
 sitefilename = ""
 global command_list,immediate_command_list,z
 command_list = []

--- a/daq_main2.py
+++ b/daq_main2.py
@@ -5,6 +5,7 @@ The main server for the LSDC system
 import sys
 import os
 from daq_main_common import pybass_init, run_server
+from config_params import LSDC_SERVICE_USERS
 
 #TODO understand why imports are required here - GUI requires imports in daq_main_common
 from daq_macros import *
@@ -28,7 +29,7 @@ handler2.setFormatter(myformat)
 logger.addHandler(handler1)
 logger.addHandler(handler2)
 
-if not getpass.getuser().startswith("lsdc-"):
+if not getpass.getuser() in LSDC_SERVICE_USERS:
     message = "LSDC server not being started by a LSDC service user account, aborting!"
     print(message)
     logger.error(message)

--- a/lsdcServer
+++ b/lsdcServer
@@ -1,3 +1,3 @@
-dzdo pkill -KILL -f daq_main2.py
+pkill -KILL -f daq_main2.py
 source /opt/conda_envs/lsdc-server-2023-1-latest/bin/activate
 $LSDCHOME/daq_main2.py


### PR DESCRIPTION
- remove dzdo when killing existing LSDC servers - they should all be owned by the service user now
- check that a service user is running the server - stop if not. otherwise, calls to processing, writing to log files and other functions will be done by the human user, potentially leading to issues (such as requiring Kerberos for processing, SSH key issues...)

For now, we will discuss the issues of beamline staff having no access to the LSDC server terminal, which may be problematic when handling operational issues. Will leave this issue draft until that is resolved.