### PR TITLE
Lifetime fixes

### DIFF
--- a/albulaUtils.py
+++ b/albulaUtils.py
@@ -91,7 +91,7 @@ def _albulaDispFile(filename):
             logger.info('reading file: %s' % filename[0])
             albulaSubFrame.loadFile(filename[0])
             currentMasterH5 = filename[0]
-            sleep(0.3) # Sleep to allow Albula to load file. Otherwise the following goTo() is ignored
+            sleep(0.5) # Sleep to allow Albula to load file. Otherwise the following goTo() is ignored
         logger.debug('reading image number %s' % filename[1])
         albulaSubFrame.goTo(filename[1])
     except dectris.albula.DNoObject:

--- a/config_params.py
+++ b/config_params.py
@@ -84,3 +84,6 @@ VALID_DET_DIST = {'amx':{'min': 100, 'max':500, 'digits':3}, 'fmx':{'min':137, '
 VALID_TOTAL_EXP_TIMES = {'amx':{'min':0.005, 'max':300, 'digits':3}, 'fmx':{'min':0.01, 'max':300, 'digits':3}, 'nyx':{'min':0.01, 'max':1000, 'digits':3}}
 VALID_PREFIX_LENGTH = 25 #TODO centralize with spreadsheet validation?
 VALID_PREFIX_NAME = '[0-9a-zA-Z-_]{0,%s}' % VALID_PREFIX_LENGTH
+VALID_TRANSMISSION = {'amx': {'min': 0.001, 'max': 1.0, 'digits': 3},
+                      'fmx': {'min': 0.001, 'max': 1.0, 'digits': 3},
+                      'nyx': {'min': 0.001, 'max': 0.999, 'digits': 3}}

--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -2547,7 +2547,8 @@ class ControlMain(QtWidgets.QMainWindow):
             )
             self.osc_start_ledit.setEnabled(True)
             self.osc_end_ledit.setEnabled(True)
-            self.calcLifetimeCB()
+            if daq_utils.beamline == 'fmx':
+                self.calcLifetimeCB()
         elif protocol == "burn":
             self.setGuiValues(
                 {
@@ -2572,7 +2573,8 @@ class ControlMain(QtWidgets.QMainWindow):
             self.osc_start_ledit.setEnabled(True)
             self.osc_end_ledit.setEnabled(True)
             self.protoVectorRadio.setChecked(True)
-            self.calcLifetimeCB()
+            if daq_utils.beamline == 'fmx':
+                self.calcLifetimeCB()
         else:
             self.protoOtherRadio.setChecked(True)
         self.totalExpChanged("")


### PR DESCRIPTION
Changes in response to feedback from FMX:
- Previously, any change in transmission text box would trigger raddose calculations in a QThread. This would lead to spawning multiple threads that would update lifetime values as the value in the text box changes. One of these threads with outdated input value would finish last and update lifetime with an incorrect value.
- To fix that, a timer grays out the previous value, waits for 1 second after the text box stops changing before triggering a calculation. This way only one thread is spawned and visually is visually cleaner
- Similarly, when a user clicks on vector protocol radio button, the vector length is considered for lifetime calculation otherwise vector length is set to 0. This also uses the same timer delay of 1 second
