### PR TITLE
Initial attempt at extracting certain frames from the main window

### DIFF
--- a/gui/acquisition/__init__.py
+++ b/gui/acquisition/__init__.py
@@ -1,3 +1,3 @@
 from .vector_params import VectorParamsFrame
 from .multicol_params import MultiColParamsFrame
-
+from .characterize_params import CharacterizeParamsFrame

--- a/gui/acquisition/__init__.py
+++ b/gui/acquisition/__init__.py
@@ -1,2 +1,3 @@
 from .vector_params import VectorParamsFrame
+from .multicol_params import MultiColParamsFrame
 

--- a/gui/acquisition/__init__.py
+++ b/gui/acquisition/__init__.py
@@ -1,0 +1,2 @@
+from .vector_params import VectorParamsFrame
+

--- a/gui/acquisition/__init__.py
+++ b/gui/acquisition/__init__.py
@@ -1,3 +1,4 @@
 from .vector_params import VectorParamsFrame
 from .multicol_params import MultiColParamsFrame
 from .characterize_params import CharacterizeParamsFrame
+from .raster_params import RasterParamsFrame

--- a/gui/acquisition/__init__.py
+++ b/gui/acquisition/__init__.py
@@ -2,3 +2,4 @@ from .vector_params import VectorParamsFrame
 from .multicol_params import MultiColParamsFrame
 from .characterize_params import CharacterizeParamsFrame
 from .raster_params import RasterParamsFrame
+from .processing_options import ProcessingOptionsFrame

--- a/gui/acquisition/characterize_params.py
+++ b/gui/acquisition/characterize_params.py
@@ -1,0 +1,55 @@
+from qtpy import QtWidgets, QtCore
+
+
+class CharacterizeParamsFrame(QtWidgets.QFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        vBoxCharacterizeParams1 = QtWidgets.QVBoxLayout()
+        self.hBoxCharacterizeLayout1 = QtWidgets.QHBoxLayout()
+        self.characterizeTargetLabel = QtWidgets.QLabel("Characterization Targets")
+        characterizeResoLabel = QtWidgets.QLabel("Resolution")
+        characterizeResoLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeResoEdit = QtWidgets.QLineEdit("3.0")
+        characterizeISIGLabel = QtWidgets.QLabel("I/Sigma")
+        characterizeISIGLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeISIGEdit = QtWidgets.QLineEdit("2.0")
+        self.characterizeAnomCheckBox = QtWidgets.QCheckBox("Anomolous")
+        self.characterizeAnomCheckBox.setChecked(False)
+        self.hBoxCharacterizeLayout2 = QtWidgets.QHBoxLayout()
+        characterizeCompletenessLabel = QtWidgets.QLabel("Completeness")
+        characterizeCompletenessLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeCompletenessEdit = QtWidgets.QLineEdit("0.99")
+        characterizeMultiplicityLabel = QtWidgets.QLabel("Multiplicity")
+        characterizeMultiplicityLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeMultiplicityEdit = QtWidgets.QLineEdit("auto")
+        characterizeDoseLimitLabel = QtWidgets.QLabel("Dose Limit")
+        characterizeDoseLimitLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeDoseLimitEdit = QtWidgets.QLineEdit("100")
+        characterizeSpaceGroupLabel = QtWidgets.QLabel("Space Group")
+        characterizeSpaceGroupLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.characterizeSpaceGroupEdit = QtWidgets.QLineEdit("P1")
+        self.hBoxCharacterizeLayout1.addWidget(characterizeResoLabel)
+        self.hBoxCharacterizeLayout1.addWidget(self.characterizeResoEdit)
+        self.hBoxCharacterizeLayout1.addWidget(characterizeISIGLabel)
+        self.hBoxCharacterizeLayout1.addWidget(self.characterizeISIGEdit)
+        self.hBoxCharacterizeLayout1.addWidget(characterizeSpaceGroupLabel)
+        self.hBoxCharacterizeLayout1.addWidget(self.characterizeSpaceGroupEdit)
+        self.hBoxCharacterizeLayout1.addWidget(self.characterizeAnomCheckBox)
+        self.hBoxCharacterizeLayout2.addWidget(characterizeCompletenessLabel)
+        self.hBoxCharacterizeLayout2.addWidget(self.characterizeCompletenessEdit)
+        self.hBoxCharacterizeLayout2.addWidget(characterizeMultiplicityLabel)
+        self.hBoxCharacterizeLayout2.addWidget(self.characterizeMultiplicityEdit)
+        self.hBoxCharacterizeLayout2.addWidget(characterizeDoseLimitLabel)
+        self.hBoxCharacterizeLayout2.addWidget(self.characterizeDoseLimitEdit)
+        vBoxCharacterizeParams1.addWidget(self.characterizeTargetLabel)
+        vBoxCharacterizeParams1.addLayout(self.hBoxCharacterizeLayout1)
+        vBoxCharacterizeParams1.addLayout(self.hBoxCharacterizeLayout2)
+        self.setLayout(vBoxCharacterizeParams1)
+
+    def get_params(self):
+        return {
+            "aimed_completeness": float(self.characterizeCompletenessEdit.text()),
+            "aimed_multiplicity": str(self.characterizeMultiplicityEdit.text()),
+            "aimed_resolution": float(self.characterizeResoEdit.text()),
+            "aimed_ISig": float(self.characterizeISIGEdit.text()),
+        }

--- a/gui/acquisition/multicol_params.py
+++ b/gui/acquisition/multicol_params.py
@@ -1,0 +1,18 @@
+from qtpy import QtWidgets, QtCore
+
+
+class MultiColParamsFrame(QtWidgets.QFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.hBoxMultiColParamsLayout1 = QtWidgets.QHBoxLayout()
+        self.hBoxMultiColParamsLayout1.setAlignment(QtCore.Qt.AlignLeft)
+        multiColCutoffLabel = QtWidgets.QLabel("Diffraction Cutoff")
+        multiColCutoffLabel.setFixedWidth(110)
+        self.multiColCutoffEdit = QtWidgets.QLineEdit(
+            "320"
+        )  # may need to store this in DB at some point, it's a silly number for now
+        self.multiColCutoffEdit.setFixedWidth(60)
+        self.hBoxMultiColParamsLayout1.addWidget(multiColCutoffLabel)
+        self.hBoxMultiColParamsLayout1.addWidget(self.multiColCutoffEdit)
+        self.setLayout(self.hBoxMultiColParamsLayout1)
+

--- a/gui/acquisition/processing_options.py
+++ b/gui/acquisition/processing_options.py
@@ -1,0 +1,33 @@
+from qtpy import QtWidgets, QtCore
+
+
+class ProcessingOptionsFrame(QtWidgets.QFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.hBoxProcessingLayout1 = QtWidgets.QHBoxLayout()
+        self.hBoxProcessingLayout1.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
+        procOptionLabel = QtWidgets.QLabel("Processing Options:")
+        procOptionLabel.setFixedWidth(200)
+        self.autoProcessingCheckBox = QtWidgets.QCheckBox("AutoProcessing On")
+        self.autoProcessingCheckBox.setChecked(True)
+        self.autoProcessingCheckBox.stateChanged.connect(self.autoProcessingCheckCB)
+        self.fastEPCheckBox = QtWidgets.QCheckBox("FastEP")
+        self.fastEPCheckBox.setChecked(False)
+        self.fastEPCheckBox.setEnabled(False)
+        self.dimpleCheckBox = QtWidgets.QCheckBox("Dimple")
+        self.dimpleCheckBox.setChecked(True)
+        self.xia2CheckBox = QtWidgets.QCheckBox("Xia2")
+        self.xia2CheckBox.setChecked(False)
+        self.hBoxProcessingLayout1.addWidget(self.autoProcessingCheckBox)
+        self.hBoxProcessingLayout1.addWidget(self.fastEPCheckBox)
+        self.hBoxProcessingLayout1.addWidget(self.dimpleCheckBox)
+        self.setLayout(self.hBoxProcessingLayout1)
+
+    def autoProcessingCheckCB(self, state):
+        if state == QtCore.Qt.CheckState.Checked:
+            self.dimpleCheckBox.setEnabled(True)
+            self.xia2CheckBox.setEnabled(True)
+        else:
+            self.fastEPCheckBox.setEnabled(False)
+            self.dimpleCheckBox.setEnabled(False)
+            self.xia2CheckBox.setEnabled(False)

--- a/gui/acquisition/raster_params.py
+++ b/gui/acquisition/raster_params.py
@@ -1,0 +1,105 @@
+from qtpy import QtWidgets, QtCore, QtGui
+from enum import Enum
+import typing
+import db_lib, daq_utils
+
+if typing.TYPE_CHECKING:
+    from gui.control_main import ControlMain
+
+
+class RasterStep(float, Enum):
+    COARSE = 20.0
+    FINE = 10.0
+    VFINE = 5.0
+
+
+class RasterParamsFrame(QtWidgets.QFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.rasterStep: float = RasterStep.COARSE.value
+
+        self.vBoxRasterParams = QtWidgets.QVBoxLayout()
+        self.hBoxRasterLayout1 = QtWidgets.QHBoxLayout()
+        self.hBoxRasterLayout1.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
+        self.hBoxRasterLayout2 = QtWidgets.QHBoxLayout()
+        self.hBoxRasterLayout2.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
+        rasterStepLabel = QtWidgets.QLabel("Raster Step")
+        rasterStepLabel.setFixedWidth(110)
+        self.rasterStepEdit = QtWidgets.QLineEdit(str(RasterStep.COARSE.value))
+        self.rasterStepEdit.setValidator(QtGui.QDoubleValidator())
+        self.rasterStepEdit.textChanged.connect(self.rasterStepChanged)
+        self.rasterStepEdit.setFixedWidth(60)
+        self.rasterGrainRadioGroup = QtWidgets.QButtonGroup()
+        self.rasterGrainCoarseRadio = QtWidgets.QRadioButton("Coarse")
+        self.rasterGrainCoarseRadio.setChecked(False)
+        self.rasterGrainCoarseRadio.toggled.connect(
+            lambda: self.rasterGrainToggledCB(RasterStep.COARSE)
+        )
+        self.rasterGrainRadioGroup.addButton(self.rasterGrainCoarseRadio)
+        self.rasterGrainFineRadio = QtWidgets.QRadioButton("Fine")
+        self.rasterGrainFineRadio.setChecked(False)
+        self.rasterGrainFineRadio.toggled.connect(
+            lambda: self.rasterGrainToggledCB(RasterStep.FINE)
+        )
+        self.rasterGrainRadioGroup.addButton(self.rasterGrainFineRadio)
+        self.rasterGrainVFineRadio = QtWidgets.QRadioButton("VFine")
+        self.rasterGrainVFineRadio.setChecked(False)
+        self.rasterGrainVFineRadio.toggled.connect(
+            lambda: self.rasterGrainToggledCB(RasterStep.VFINE)
+        )
+        self.rasterGrainRadioGroup.addButton(self.rasterGrainVFineRadio)
+        self.rasterGrainCustomRadio = QtWidgets.QRadioButton("Custom")
+        self.rasterGrainCustomRadio.setChecked(True)
+        self.rasterGrainCustomRadio.toggled.connect(
+            lambda: self.rasterStepChanged(self.rasterStepEdit.text())
+        )
+        self.rasterGrainRadioGroup.addButton(self.rasterGrainCustomRadio)
+        rasterEvalLabel = QtWidgets.QLabel("Raster\nEvaluate By:")
+        rasterEvalOptionList = ["Spot Count", "Resolution", "Intensity"]
+        self.rasterEvalComboBox = QtWidgets.QComboBox(self)
+        self.rasterEvalComboBox.addItems(rasterEvalOptionList)
+        self.rasterEvalComboBox.setCurrentIndex(
+            db_lib.beamlineInfo(daq_utils.beamline, "rasterScoreFlag")["index"]
+        )
+        self.rasterEvalComboBox.activated.connect(self.rasterEvalComboActivatedCB)
+        self.hBoxRasterLayout1.addWidget(rasterStepLabel)
+        self.hBoxRasterLayout1.addWidget(self.rasterStepEdit)
+        self.hBoxRasterLayout1.addWidget(self.rasterGrainCoarseRadio)
+        self.hBoxRasterLayout1.addWidget(self.rasterGrainFineRadio)
+        self.hBoxRasterLayout1.addWidget(self.rasterGrainVFineRadio)
+        self.hBoxRasterLayout1.addWidget(self.rasterGrainCustomRadio)
+        self.hBoxRasterLayout1.addWidget(rasterEvalLabel)
+        self.hBoxRasterLayout1.addWidget(self.rasterEvalComboBox)
+        self.vBoxRasterParams.addLayout(self.hBoxRasterLayout1)
+        self.vBoxRasterParams.addLayout(self.hBoxRasterLayout2)
+        self.setLayout(self.vBoxRasterParams)
+
+    def rasterGrainToggledCB(self, identifier: RasterStep):
+        self.rasterStepEdit.setText(str(identifier.value))
+        self.rasterStep = identifier.value
+
+    def rasterStepChanged(self, text):
+        self.rasterStep = float(text)
+
+    def rasterEvalComboActivatedCB(self, text):
+        db_lib.beamlineInfo(
+            daq_utils.beamline,
+            "rasterScoreFlag",
+            info_dict={"index": self.rasterEvalComboBox.findText(str(text))},
+        )
+        if self.parent().currentRasterCellList != []:
+            self.parent().reFillPolyRaster()
+
+    def parent(self):
+        return typing.cast("ControlMain", super().parent())
+
+    def setGridStep(self, value: float):
+        self.rasterStepEdit.setText(str(value))
+        if value == RasterStep.COARSE:
+            self.rasterGrainCoarseRadio.setChecked(True)
+        elif value == RasterStep.FINE:
+            self.rasterGrainFineRadio.setChecked(True)
+        elif value == RasterStep.VFINE:
+            self.rasterGrainVFineRadio.setChecked(True)
+        else:
+            self.rasterGrainCustomRadio.setChecked(True)

--- a/gui/acquisition/vector_params.py
+++ b/gui/acquisition/vector_params.py
@@ -1,0 +1,43 @@
+from qtpy import QtWidgets
+from qtpy.QtGui import QIntValidator
+import typing
+
+if typing.TYPE_CHECKING:
+    from gui.control_main import ControlMain
+
+
+class VectorParamsFrame(QtWidgets.QFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        hBoxVectorLayout1 = QtWidgets.QHBoxLayout()
+        setVectorStartButton = QtWidgets.QPushButton("Vector\nStart")
+        setVectorStartButton.setStyleSheet("background-color: blue")
+        setVectorStartButton.clicked.connect(
+            lambda: self.parent().setVectorPointCB("vectorStart")
+        )
+        setVectorEndButton = QtWidgets.QPushButton("Vector\nEnd")
+        setVectorEndButton.setStyleSheet("background-color: red")
+        setVectorEndButton.clicked.connect(
+            lambda: self.parent().setVectorPointCB("vectorEnd")
+        )
+        self.vecLine = None
+        vectorFPPLabel = QtWidgets.QLabel("Number of Wedges")
+        self.vectorFPP_ledit = QtWidgets.QLineEdit("1")
+        self.vectorFPP_ledit.setValidator(QIntValidator(self))
+        vecLenLabel = QtWidgets.QLabel("    Length(microns):")
+        self.vecLenLabelOutput = QtWidgets.QLabel("---")
+        vecSpeedLabel = QtWidgets.QLabel("    Speed(microns/s):")
+        self.vecSpeedLabelOutput = QtWidgets.QLabel("---")
+        hBoxVectorLayout1.addWidget(setVectorStartButton)
+        hBoxVectorLayout1.addWidget(setVectorEndButton)
+        hBoxVectorLayout1.addWidget(vectorFPPLabel)
+        hBoxVectorLayout1.addWidget(self.vectorFPP_ledit)
+        hBoxVectorLayout1.addWidget(vecLenLabel)
+        hBoxVectorLayout1.addWidget(self.vecLenLabelOutput)
+        hBoxVectorLayout1.addWidget(vecSpeedLabel)
+        hBoxVectorLayout1.addWidget(self.vecSpeedLabelOutput)
+        self.setLayout(hBoxVectorLayout1)
+
+    def parent(self):
+        return typing.cast("ControlMain", super().parent())
+

--- a/gui/acquisition/vector_params.py
+++ b/gui/acquisition/vector_params.py
@@ -20,7 +20,6 @@ class VectorParamsFrame(QtWidgets.QFrame):
         setVectorEndButton.clicked.connect(
             lambda: self.parent().setVectorPointCB("vectorEnd")
         )
-        self.vecLine = None
         vectorFPPLabel = QtWidgets.QLabel("Number of Wedges")
         self.vectorFPP_ledit = QtWidgets.QLineEdit("1")
         self.vectorFPP_ledit.setValidator(QIntValidator(self))

--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -52,6 +52,7 @@ from gui.acquisition import (
     MultiColParamsFrame,
     CharacterizeParamsFrame,
     RasterParamsFrame,
+    ProcessingOptionsFrame,
 )
 from gui.raster import RasterCell, RasterGroup
 from QPeriodicTable import QPeriodicTable
@@ -676,25 +677,7 @@ class ControlMain(QtWidgets.QMainWindow):
         hBoxColParams7.addWidget(self.centeringComboBox)
         hBoxColParams7.addWidget(colResoLabel)
         hBoxColParams7.addWidget(self.resolution_ledit)
-        self.processingOptionsFrame = QFrame()
-        self.hBoxProcessingLayout1 = QtWidgets.QHBoxLayout()
-        self.hBoxProcessingLayout1.setAlignment(QtCore.Qt.AlignLeft)
-        procOptionLabel = QtWidgets.QLabel("Processing Options:")
-        procOptionLabel.setFixedWidth(200)
-        self.autoProcessingCheckBox = QCheckBox("AutoProcessing On")
-        self.autoProcessingCheckBox.setChecked(True)
-        self.autoProcessingCheckBox.stateChanged.connect(self.autoProcessingCheckCB)
-        self.fastEPCheckBox = QCheckBox("FastEP")
-        self.fastEPCheckBox.setChecked(False)
-        self.fastEPCheckBox.setEnabled(False)
-        self.dimpleCheckBox = QCheckBox("Dimple")
-        self.dimpleCheckBox.setChecked(True)
-        self.xia2CheckBox = QCheckBox("Xia2")
-        self.xia2CheckBox.setChecked(False)
-        self.hBoxProcessingLayout1.addWidget(self.autoProcessingCheckBox)
-        self.hBoxProcessingLayout1.addWidget(self.fastEPCheckBox)
-        self.hBoxProcessingLayout1.addWidget(self.dimpleCheckBox)
-        self.processingOptionsFrame.setLayout(self.hBoxProcessingLayout1)
+        self.processingOptionsFrame = ProcessingOptionsFrame(self)
         self.rasterParamsFrame = RasterParamsFrame(self)
         self.multiColParamsFrame = MultiColParamsFrame(self)
         self.characterizeParamsFrame = CharacterizeParamsFrame(self)
@@ -1233,9 +1216,9 @@ class ControlMain(QtWidgets.QMainWindow):
             self.protoStandardRadio.setDisabled(True)
             self.protoVectorRadio.setDisabled(True)
             self.protoOtherRadio.setDisabled(True)
-            self.autoProcessingCheckBox.setDisabled(True)
-            self.fastEPCheckBox.setDisabled(True)
-            self.dimpleCheckBox.setDisabled(True)
+            self.processingOptionsFrame.autoProcessingCheckBox.setDisabled(True)
+            self.processingOptionsFrame.fastEPCheckBox.setDisabled(True)
+            self.processingOptionsFrame.dimpleCheckBox.setDisabled(True)
             self.centeringComboBox.setDisabled(True)
             self.beamsizeComboBox.setDisabled(True)
             annealButton.setDisabled(True)
@@ -1309,15 +1292,6 @@ class ControlMain(QtWidgets.QMainWindow):
                 self.stillModeCheckBox.setChecked(True)
             else:
                 self.stillModeCheckBox.setChecked(False)
-
-    def autoProcessingCheckCB(self, state):
-        if state == QtCore.Qt.Checked:
-            self.dimpleCheckBox.setEnabled(True)
-            self.xia2CheckBox.setEnabled(True)
-        else:
-            self.fastEPCheckBox.setEnabled(False)
-            self.dimpleCheckBox.setEnabled(False)
-            self.xia2CheckBox.setEnabled(False)
 
     def vidActionToggledCB(self):
         if len(self.rasterList) > 0:
@@ -3535,12 +3509,12 @@ class ControlMain(QtWidgets.QMainWindow):
             return
         reqObj["fastDP"] = (
             self.staffScreenDialog.fastDPCheckBox.isChecked()
-            or self.fastEPCheckBox.isChecked()
-            or self.dimpleCheckBox.isChecked()
+            or self.processingOptionsFrame.fastEPCheckBox.isChecked()
+            or self.processingOptionsFrame.dimpleCheckBox.isChecked()
         )
-        reqObj["fastEP"] = self.fastEPCheckBox.isChecked()
-        reqObj["dimple"] = self.dimpleCheckBox.isChecked()
-        reqObj["xia2"] = self.xia2CheckBox.isChecked()
+        reqObj["fastEP"] = self.processingOptionsFrame.fastEPCheckBox.isChecked()
+        reqObj["dimple"] = self.processingOptionsFrame.dimpleCheckBox.isChecked()
+        reqObj["xia2"] = self.processingOptionsFrame.xia2CheckBox.isChecked()
         reqObj["protocol"] = str(self.protoComboBox.currentText())
         if reqObj["protocol"] == "vector" or reqObj["protocol"] == "stepVector":
             reqObj["vectorParams"]["fpp"] = int(
@@ -3821,12 +3795,18 @@ class ControlMain(QtWidgets.QMainWindow):
                     )
                     reqObj["fastDP"] = (
                         self.staffScreenDialog.fastDPCheckBox.isChecked()
-                        or self.fastEPCheckBox.isChecked()
-                        or self.dimpleCheckBox.isChecked()
+                        or self.processingOptionsFrame.fastEPCheckBox.isChecked()
+                        or self.processingOptionsFrame.dimpleCheckBox.isChecked()
                     )
-                    reqObj["fastEP"] = self.fastEPCheckBox.isChecked()
-                    reqObj["dimple"] = self.dimpleCheckBox.isChecked()
-                    reqObj["xia2"] = self.xia2CheckBox.isChecked()
+                    reqObj[
+                        "fastEP"
+                    ] = self.processingOptionsFrame.fastEPCheckBox.isChecked()
+                    reqObj[
+                        "dimple"
+                    ] = self.processingOptionsFrame.dimpleCheckBox.isChecked()
+                    reqObj[
+                        "xia2"
+                    ] = self.processingOptionsFrame.xia2CheckBox.isChecked()
                     if (
                         reqObj["protocol"] == "characterize"
                         or reqObj["protocol"] == "ednaCol"
@@ -3920,12 +3900,16 @@ class ControlMain(QtWidgets.QMainWindow):
                 else:
                     reqObj["fastDP"] = (
                         self.staffScreenDialog.fastDPCheckBox.isChecked()
-                        or self.fastEPCheckBox.isChecked()
-                        or self.dimpleCheckBox.isChecked()
+                        or self.processingOptionsFrame.fastEPCheckBox.isChecked()
+                        or self.processingOptionsFrame.dimpleCheckBox.isChecked()
                     )
-                    reqObj["fastEP"] = self.fastEPCheckBox.isChecked()
-                    reqObj["dimple"] = self.dimpleCheckBox.isChecked()
-                reqObj["xia2"] = self.xia2CheckBox.isChecked()
+                    reqObj[
+                        "fastEP"
+                    ] = self.processingOptionsFrame.fastEPCheckBox.isChecked()
+                    reqObj[
+                        "dimple"
+                    ] = self.processingOptionsFrame.dimpleCheckBox.isChecked()
+                reqObj["xia2"] = self.processingOptionsFrame.xia2CheckBox.isChecked()
                 reqObj["attenuation"] = float(self.transmission_ledit.text())
                 reqObj["slit_width"] = self.rasterParamsFrame.rasterStep
                 reqObj["slit_height"] = self.rasterParamsFrame.rasterStep
@@ -4332,11 +4316,11 @@ class ControlMain(QtWidgets.QMainWindow):
                 (reqObj["fastDP"] or reqObj["fastEP"] or reqObj["dimple"])
             )
         if "fastEP" in reqObj:
-            self.fastEPCheckBox.setChecked(reqObj["fastEP"])
+            self.processingOptionsFrame.fastEPCheckBox.setChecked(reqObj["fastEP"])
         if "dimple" in reqObj:
-            self.dimpleCheckBox.setChecked(reqObj["dimple"])
+            self.processingOptionsFrame.dimpleCheckBox.setChecked(reqObj["dimple"])
         if "xia2" in reqObj:
-            self.xia2CheckBox.setChecked(reqObj["xia2"])
+            self.processingOptionsFrame.xia2CheckBox.setChecked(reqObj["xia2"])
         reqObj["energy"] = float(self.energy_ledit.text())
         self.energy_ledit.setText(str(reqObj["energy"]))
         energy_s = str(daq_utils.wave2energy(reqObj["wavelength"], digits=6))

--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -48,7 +48,7 @@ from gui.dialog import (
     StaffScreenDialog,
     UserScreenDialog,
 )
-from gui.acquisition import VectorParamsFrame
+from gui.acquisition import VectorParamsFrame, MultiColParamsFrame
 from gui.raster import RasterCell, RasterGroup
 from QPeriodicTable import QPeriodicTable
 from threads import RaddoseThread, VideoThread
@@ -763,20 +763,7 @@ class ControlMain(QtWidgets.QMainWindow):
         self.vBoxRasterParams.addLayout(self.hBoxRasterLayout1)
         self.vBoxRasterParams.addLayout(self.hBoxRasterLayout2)
         self.rasterParamsFrame.setLayout(self.vBoxRasterParams)
-        self.multiColParamsFrame = (
-            QFrame()
-        )  # something for criteria to decide on which hotspots to collect on for multi-xtal
-        self.hBoxMultiColParamsLayout1 = QtWidgets.QHBoxLayout()
-        self.hBoxMultiColParamsLayout1.setAlignment(QtCore.Qt.AlignLeft)
-        multiColCutoffLabel = QtWidgets.QLabel("Diffraction Cutoff")
-        multiColCutoffLabel.setFixedWidth(110)
-        self.multiColCutoffEdit = QtWidgets.QLineEdit(
-            "320"
-        )  # may need to store this in DB at some point, it's a silly number for now
-        self.multiColCutoffEdit.setFixedWidth(60)
-        self.hBoxMultiColParamsLayout1.addWidget(multiColCutoffLabel)
-        self.hBoxMultiColParamsLayout1.addWidget(self.multiColCutoffEdit)
-        self.multiColParamsFrame.setLayout(self.hBoxMultiColParamsLayout1)
+        self.multiColParamsFrame = MultiColParamsFrame(self)
         self.characterizeParamsFrame = QFrame()
         vBoxCharacterizeParams1 = QtWidgets.QVBoxLayout()
         self.hBoxCharacterizeLayout1 = QtWidgets.QHBoxLayout()
@@ -4098,7 +4085,7 @@ class ControlMain(QtWidgets.QMainWindow):
                 reqObj["detDist"] = new_distance
             if reqObj["protocol"] == "multiCol" or reqObj["protocol"] == "multiColQ":
                 reqObj["gridStep"] = float(self.rasterStepEdit.text())
-                reqObj["diffCutoff"] = float(self.multiColCutoffEdit.text())
+                reqObj["diffCutoff"] = float(self.multiColParamsFrame.multiColCutoffEdit.text())
             if reqObj["protocol"] == "rasterScreen":
                 reqObj["gridStep"] = float(self.rasterStepEdit.text())
             if rasterDef != None:

--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -1,4 +1,3 @@
-import _thread
 import functools
 import logging
 import math
@@ -52,6 +51,7 @@ from gui.acquisition import (
     VectorParamsFrame,
     MultiColParamsFrame,
     CharacterizeParamsFrame,
+    RasterParamsFrame,
 )
 from gui.raster import RasterCell, RasterGroup
 from QPeriodicTable import QPeriodicTable
@@ -200,7 +200,6 @@ class ControlMain(QtWidgets.QMainWindow):
 
         self.beamSize_pv = PV(daq_utils.beamlineComm + "size_mode")
         self.energy_pv = PV(daq_utils.motor_dict["energy"] + ".RBV")
-        self.rasterStepDefs = {"Coarse": 20.0, "Fine": 10.0, "VFine": 5.0}
 
         # Timer that waits for a second before calling raddose 3d
         # This is to prevent multiple calls when transmission textbox is changing
@@ -574,22 +573,6 @@ class ControlMain(QtWidgets.QMainWindow):
         hBoxColParams22.insertSpacing(5, 100)
         hBoxColParams22.addWidget(beamsizeLabel)
         hBoxColParams22.addWidget(self.beamsizeComboBox)
-        hBoxColParams4 = QtWidgets.QHBoxLayout()
-        colBeamWLabel = QtWidgets.QLabel("Beam Width:")
-        colBeamWLabel.setFixedWidth(140)
-        colBeamWLabel.setAlignment(QtCore.Qt.AlignCenter)
-        self.beamWidth_ledit = QtWidgets.QLineEdit()
-        self.beamWidth_ledit.setFixedWidth(60)
-        colBeamHLabel = QtWidgets.QLabel("Beam Height:")
-        colBeamHLabel.setFixedWidth(140)
-        colBeamHLabel.setAlignment(QtCore.Qt.AlignCenter)
-        self.beamHeight_ledit = QtWidgets.QLineEdit()
-        self.beamHeight_ledit.setFixedWidth(60)
-        hBoxColParams4.addWidget(colBeamWLabel)
-        hBoxColParams4.addWidget(self.beamWidth_ledit)
-        hBoxColParams4.addWidget(colBeamHLabel)
-        hBoxColParams4.addWidget(self.beamHeight_ledit)
-        hBoxColParams5 = QtWidgets.QHBoxLayout()
         colResoLabel = QtWidgets.QLabel("Edge Resolution:")
         colResoLabel.setAlignment(QtCore.Qt.AlignCenter)
         self.resolution_ledit = QtWidgets.QLineEdit()
@@ -712,61 +695,7 @@ class ControlMain(QtWidgets.QMainWindow):
         self.hBoxProcessingLayout1.addWidget(self.fastEPCheckBox)
         self.hBoxProcessingLayout1.addWidget(self.dimpleCheckBox)
         self.processingOptionsFrame.setLayout(self.hBoxProcessingLayout1)
-        self.rasterParamsFrame = QFrame()
-        self.vBoxRasterParams = QtWidgets.QVBoxLayout()
-        self.hBoxRasterLayout1 = QtWidgets.QHBoxLayout()
-        self.hBoxRasterLayout1.setAlignment(QtCore.Qt.AlignLeft)
-        self.hBoxRasterLayout2 = QtWidgets.QHBoxLayout()
-        self.hBoxRasterLayout2.setAlignment(QtCore.Qt.AlignLeft)
-        rasterStepLabel = QtWidgets.QLabel("Raster Step")
-        rasterStepLabel.setFixedWidth(110)
-        self.rasterStepEdit = QtWidgets.QLineEdit(str(self.rasterStepDefs["Coarse"]))
-        self.rasterStepEdit.textChanged[str].connect(self.rasterStepChanged)
-        self.rasterStepEdit.setFixedWidth(60)
-        self.rasterGrainRadioGroup = QtWidgets.QButtonGroup()
-        self.rasterGrainCoarseRadio = QtWidgets.QRadioButton("Coarse")
-        self.rasterGrainCoarseRadio.setChecked(False)
-        self.rasterGrainCoarseRadio.toggled.connect(
-            functools.partial(self.rasterGrainToggledCB, "Coarse")
-        )
-        self.rasterGrainRadioGroup.addButton(self.rasterGrainCoarseRadio)
-        self.rasterGrainFineRadio = QtWidgets.QRadioButton("Fine")
-        self.rasterGrainFineRadio.setChecked(False)
-        self.rasterGrainFineRadio.toggled.connect(
-            functools.partial(self.rasterGrainToggledCB, "Fine")
-        )
-        self.rasterGrainRadioGroup.addButton(self.rasterGrainFineRadio)
-        self.rasterGrainVFineRadio = QtWidgets.QRadioButton("VFine")
-        self.rasterGrainVFineRadio.setChecked(False)
-        self.rasterGrainVFineRadio.toggled.connect(
-            functools.partial(self.rasterGrainToggledCB, "VFine")
-        )
-        self.rasterGrainRadioGroup.addButton(self.rasterGrainVFineRadio)
-        self.rasterGrainCustomRadio = QtWidgets.QRadioButton("Custom")
-        self.rasterGrainCustomRadio.setChecked(True)
-        self.rasterGrainCustomRadio.toggled.connect(
-            functools.partial(self.rasterGrainToggledCB, "Custom")
-        )
-        self.rasterGrainRadioGroup.addButton(self.rasterGrainCustomRadio)
-        rasterEvalLabel = QtWidgets.QLabel("Raster\nEvaluate By:")
-        rasterEvalOptionList = ["Spot Count", "Resolution", "Intensity"]
-        self.rasterEvalComboBox = QtWidgets.QComboBox(self)
-        self.rasterEvalComboBox.addItems(rasterEvalOptionList)
-        self.rasterEvalComboBox.setCurrentIndex(
-            db_lib.beamlineInfo(daq_utils.beamline, "rasterScoreFlag")["index"]
-        )
-        self.rasterEvalComboBox.activated[str].connect(self.rasterEvalComboActivatedCB)
-        self.hBoxRasterLayout1.addWidget(rasterStepLabel)
-        self.hBoxRasterLayout1.addWidget(self.rasterStepEdit)
-        self.hBoxRasterLayout1.addWidget(self.rasterGrainCoarseRadio)
-        self.hBoxRasterLayout1.addWidget(self.rasterGrainFineRadio)
-        self.hBoxRasterLayout1.addWidget(self.rasterGrainVFineRadio)
-        self.hBoxRasterLayout1.addWidget(self.rasterGrainCustomRadio)
-        self.hBoxRasterLayout1.addWidget(rasterEvalLabel)
-        self.hBoxRasterLayout1.addWidget(self.rasterEvalComboBox)
-        self.vBoxRasterParams.addLayout(self.hBoxRasterLayout1)
-        self.vBoxRasterParams.addLayout(self.hBoxRasterLayout2)
-        self.rasterParamsFrame.setLayout(self.vBoxRasterParams)
+        self.rasterParamsFrame = RasterParamsFrame(self)
         self.multiColParamsFrame = MultiColParamsFrame(self)
         self.characterizeParamsFrame = CharacterizeParamsFrame(self)
         self.vectorParamsFrame = VectorParamsFrame(self)
@@ -1389,13 +1318,6 @@ class ControlMain(QtWidgets.QMainWindow):
             self.fastEPCheckBox.setEnabled(False)
             self.dimpleCheckBox.setEnabled(False)
             self.xia2CheckBox.setEnabled(False)
-
-    def rasterGrainToggledCB(self, identifier):
-        if identifier == "Coarse" or identifier == "Fine" or identifier == "VFine":
-            cellSize = self.rasterStepDefs[identifier]
-            self.rasterStepEdit.setText(str(cellSize))
-            self.beamWidth_ledit.setText(str(cellSize))
-            self.beamHeight_ledit.setText(str(cellSize))
 
     def vidActionToggledCB(self):
         if len(self.rasterList) > 0:
@@ -2223,10 +2145,6 @@ class ControlMain(QtWidgets.QMainWindow):
         else:
             pass
 
-    def rasterStepChanged(self, text):
-        self.beamWidth_ledit.setText(text)
-        self.beamHeight_ledit.setText(text)
-
     def updateVectorLengthAndSpeed(self):
         x_vec_end = self.vectorEnd["coords"]["x"]
         y_vec_end = self.vectorEnd["coords"]["y"]
@@ -2511,15 +2429,6 @@ class ControlMain(QtWidgets.QMainWindow):
         else:
             self.protoOtherRadio.setChecked(True)
         self.totalExpChanged("")
-
-    def rasterEvalComboActivatedCB(self, text):
-        db_lib.beamlineInfo(
-            daq_utils.beamline,
-            "rasterScoreFlag",
-            info_dict={"index": self.rasterEvalComboBox.findText(str(text))},
-        )
-        if self.currentRasterCellList != []:
-            self.reFillPolyRaster()
 
     def popBaseDirectoryDialogCB(self):
         fname = QtWidgets.QFileDialog.getExistingDirectory(
@@ -2829,8 +2738,8 @@ class ControlMain(QtWidgets.QMainWindow):
         raster_h = int(self.polyBoundingRect.height())
         center_x = int(self.polyBoundingRect.center().x())
         center_y = int(self.polyBoundingRect.center().y())
-        stepsizeXPix = self.screenXmicrons2pixels(float(self.rasterStepEdit.text()))
-        stepsizeYPix = self.screenYmicrons2pixels(float(self.rasterStepEdit.text()))
+        stepsizeXPix = self.screenXmicrons2pixels(self.rasterParamsFrame.rasterStep)
+        stepsizeYPix = self.screenYmicrons2pixels(self.rasterParamsFrame.rasterStep)
         self.click_positions = []
         self.definePolyRaster(
             raster_w, raster_h, stepsizeXPix, stepsizeYPix, center_x, center_y
@@ -2905,7 +2814,7 @@ class ControlMain(QtWidgets.QMainWindow):
         spotLineCounter = 0
         cellIndex = 0
         rowStartIndex = 0
-        rasterEvalOption = str(self.rasterEvalComboBox.currentText())
+        rasterEvalOption = str(self.rasterParamsFrame.rasterEvalComboBox.currentText())
         lenX = abs(
             rasterDef["rowDefs"][0]["end"]["x"] - rasterDef["rowDefs"][0]["start"]["x"]
         )  # ugly for tile flip/noflip
@@ -3048,7 +2957,7 @@ class ControlMain(QtWidgets.QMainWindow):
             logger.error(f"Exception while writing raster result: {e}")
 
     def reFillPolyRaster(self):
-        rasterEvalOption = str(self.rasterEvalComboBox.currentText())
+        rasterEvalOption = str(self.rasterParamsFrame.rasterEvalComboBox.currentText())
         for i in range(len(self.rasterList)):
             if self.rasterList[i] != None:
                 currentRasterGroup = self.rasterList[i]["graphicsItem"]
@@ -3239,7 +3148,7 @@ class ControlMain(QtWidgets.QMainWindow):
     ):  # all come in as pixels, raster_w and raster_h are bounding box of drawn graphic
         # raster status - 0=nothing done, 1=run, 2=displayed
         stepTime = float(self.exp_time_ledit.text())
-        stepsize = float(self.rasterStepEdit.text())
+        stepsize = self.rasterParamsFrame.rasterStep
         if (stepsize / 1000.0) / stepTime > 2.0:
             self.popupServerMessage(
                 "Stage speed exceeded. Increase exposure time, or decrease step size. Limit is 2mm/s."
@@ -3248,8 +3157,7 @@ class ControlMain(QtWidgets.QMainWindow):
             return
 
         try:
-            beamWidth = float(self.beamWidth_ledit.text())
-            beamHeight = float(self.beamHeight_ledit.text())
+            beamWidth = beamHeight = self.rasterParamsFrame.rasterStep
         except ValueError:
             logger.error("bad value for beam width or beam height")
             self.popupServerMessage("bad value for beam width or beam height")
@@ -3615,8 +3523,8 @@ class ControlMain(QtWidgets.QMainWindow):
                     self.dataPathGB.file_numstart_ledit.text()
                 )
             reqObj["attenuation"] = float(self.transmission_ledit.text())
-            reqObj["slit_width"] = float(self.beamWidth_ledit.text())
-            reqObj["slit_height"] = float(self.beamHeight_ledit.text())
+            reqObj["slit_width"] = self.rasterParamsFrame.rasterStep
+            reqObj["slit_height"] = self.rasterParamsFrame.rasterStep
             reqObj["energy"] = float(self.energy_ledit.text())
             wave = daq_utils.energy2wave(float(self.energy_ledit.text()), digits=6)
             reqObj["wavelength"] = wave
@@ -3888,8 +3796,8 @@ class ControlMain(QtWidgets.QMainWindow):
                             self.dataPathGB.file_numstart_ledit.text()
                         )
                         reqObj["attenuation"] = float(self.transmission_ledit.text())
-                        reqObj["slit_width"] = float(self.beamWidth_ledit.text())
-                        reqObj["slit_height"] = float(self.beamHeight_ledit.text())
+                        reqObj["slit_width"] = self.rasterParamsFrame.rasterStep
+                        reqObj["slit_height"] = self.rasterParamsFrame.rasterStep
                         reqObj["energy"] = float(self.energy_ledit.text())
                         wave = daq_utils.energy2wave(
                             float(self.energy_ledit.text()), digits=6
@@ -4019,8 +3927,8 @@ class ControlMain(QtWidgets.QMainWindow):
                     reqObj["dimple"] = self.dimpleCheckBox.isChecked()
                 reqObj["xia2"] = self.xia2CheckBox.isChecked()
                 reqObj["attenuation"] = float(self.transmission_ledit.text())
-                reqObj["slit_width"] = float(self.beamWidth_ledit.text())
-                reqObj["slit_height"] = float(self.beamHeight_ledit.text())
+                reqObj["slit_width"] = self.rasterParamsFrame.rasterStep
+                reqObj["slit_height"] = self.rasterParamsFrame.rasterStep
                 reqObj["energy"] = float(self.energy_ledit.text())
             except ValueError:
                 message = "Please ensure that all boxes that expect numerical values have numbers in them"
@@ -4041,15 +3949,15 @@ class ControlMain(QtWidgets.QMainWindow):
                 logger.error("set dist to %s in exception handler 1" % new_distance)
                 reqObj["detDist"] = new_distance
             if reqObj["protocol"] == "multiCol" or reqObj["protocol"] == "multiColQ":
-                reqObj["gridStep"] = float(self.rasterStepEdit.text())
+                reqObj["gridStep"] = self.rasterParamsFrame.rasterStep
                 reqObj["diffCutoff"] = float(
                     self.multiColParamsFrame.multiColCutoffEdit.text()
                 )
             if reqObj["protocol"] == "rasterScreen":
-                reqObj["gridStep"] = float(self.rasterStepEdit.text())
+                reqObj["gridStep"] = self.rasterParamsFrame.rasterStep
             if rasterDef != None:
                 reqObj["rasterDef"] = rasterDef
-                reqObj["gridStep"] = float(self.rasterStepEdit.text())
+                reqObj["gridStep"] = self.rasterParamsFrame.rasterStep
             if reqObj["protocol"] == "characterize" or reqObj["protocol"] == "ednaCol":
                 reqObj[
                     "characterizationParams"
@@ -4417,8 +4325,8 @@ class ControlMain(QtWidgets.QMainWindow):
             }
         )
         self.dataPathGB.setFileNumstart_ledit(str(reqObj["file_number_start"]))
-        self.beamWidth_ledit.setText(str(reqObj["slit_width"]))
-        self.beamHeight_ledit.setText(str(reqObj["slit_height"]))
+        self.rasterParamsFrame.rasterStep = reqObj["slit_width"]
+        # self.rasterParamsFrame.beamHeight = reqObj["slit_height"]
         if "fastDP" in reqObj:
             self.staffScreenDialog.fastDPCheckBox.setChecked(
                 (reqObj["fastDP"] or reqObj["fastEP"] or reqObj["dimple"])
@@ -4470,15 +4378,8 @@ class ControlMain(QtWidgets.QMainWindow):
                                 f"Master HDF5 file {firstFilename} could not be validated",
                                 QtWidgets.QMessageBox.Ok,
                             )
-        self.rasterStepEdit.setText(str(reqObj["gridStep"]))
-        if reqObj["gridStep"] == self.rasterStepDefs["Coarse"]:
-            self.rasterGrainCoarseRadio.setChecked(True)
-        elif reqObj["gridStep"] == self.rasterStepDefs["Fine"]:
-            self.rasterGrainFineRadio.setChecked(True)
-        elif reqObj["gridStep"] == self.rasterStepDefs["VFine"]:
-            self.rasterGrainVFineRadio.setChecked(True)
-        else:
-            self.rasterGrainCustomRadio.setChecked(True)
+        self.rasterParamsFrame.setGridStep(reqObj["gridStep"])
+
         rasterStep = int(reqObj["gridStep"])
         if not self.hideRastersCheckBox.isChecked() and (
             reqObj["protocol"] in ("raster", "stepRaster", "multiCol")


### PR DESCRIPTION
This is a first attempt at removing the definition of certain parts of the acquisition frame and moving it to their own files. 
This kind of modularization will allow another beamline to inherit, pick and choose what it wants to modify by class.

This pull request consists of extracting the following frames
- Vector Params
- MultiCol params
- Characterize params
- Raster params
- Processing options params