### PR TITLE
Changed default visit dir from 999999-1234 to mx{proposalID}-1

### DIFF
--- a/daq_utils.py
+++ b/daq_utils.py
@@ -374,7 +374,7 @@ def setProposalID(proposalID,createVisit=True):
       else:
         visitName, visitNum = ispybLib.createVisitName(proposalID)
     except Exception as e:
-      visitName = "999999-1234"
+      visitName = f"mx{proposalID}-1"
       logger.error("ispyb error in set proposal. Error: %s" % e)
     setVisitName(visitName)
 


### PR DESCRIPTION
If an error is encountered when creating a visit using ispyb, default to using mx{proposalID}-1 