### PR TITLE
hard code ISPyB DC ID for fastDP processing

### DIFF
--- a/runFastDPH5.py
+++ b/runFastDPH5.py
@@ -31,7 +31,7 @@ runFastEP = int(sys.argv[4])
 node = sys.argv[5]
 runDimple = int(sys.argv[6])
 dimpleNode = sys.argv[7]
-ispybDCID = int(sys.argv[8])
+ispybDCID = 1 #int(sys.argv[8])
 
 comm_s = f"ssh -q {node} \"{os.environ['MXPROCESSINGSCRIPTSDIR']}fast_dp.sh {request_id} {numstart}\""
 logger.info(comm_s)


### PR DESCRIPTION
 * since ispybLib.insertResult() doesn't use this value, using 1 should be ok.
 * this needs to be reverted when ISPyB is re-enabled