### PR TITLE
Add refresh dewar tree button

### DIFF
--- a/db_lib.py
+++ b/db_lib.py
@@ -485,7 +485,7 @@ def getContainerByID(container_id):
     c = getContainers(filters={'uid': container_id})[0]
     return c
 
-def get_dewar_tree_data(dewar_name, beamline):
+def get_dewar_tree_data(dewar_name, beamline, get_latest_pucks=False):
     """
     returns all data required to show dewar tree data with minimum number of database accesses
     """
@@ -496,6 +496,16 @@ def get_dewar_tree_data(dewar_name, beamline):
     ]  # removes blank ids
     pucks = getContainers(filters={"uid": {"$in": puck_ids}})
 
+    if get_latest_pucks:
+        # If get_latest_pucks is true, get the puck most recently updated in the database
+        # This is for cases when the excel sheet has been uploaded after puck_to_dewar
+        # Or when staff manually refreshes the dewar tree
+        new_pucks = []
+        for puck in pucks:
+            all_pucks = getContainers(filters={"name":puck["name"]})
+            latest_puck = max(all_pucks, key=lambda x: x.get("modified_time", 0.0))
+            new_pucks.append(latest_puck)
+        pucks = new_pucks  
     # Create a mega list of sample ids from puck information
     sample_ids = [
         sample_id

--- a/gui/dewar_tree.py
+++ b/gui/dewar_tree.py
@@ -109,11 +109,11 @@ class DewarTree(QtWidgets.QTreeView):
         font.setOverline(True)
         item.setFont(font)
 
-    def refreshTreeDewarView(self):
+    def refreshTreeDewarView(self, get_latest_pucks=False):
         puck = ""
         self.model.clear()
         dewar_data, puck_data, sample_data, request_data = db_lib.get_dewar_tree_data(
-            daq_utils.primaryDewarName, daq_utils.beamline
+            daq_utils.primaryDewarName, daq_utils.beamline, get_latest_pucks
         )
         parentItem = self.model.invisibleRootItem()
         for i, puck_id in enumerate(

--- a/gui/dialog/staff_screen.py
+++ b/gui/dialog/staff_screen.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QCheckBox
 
 from config_params import BEAM_CHECK, TOP_VIEW_CHECK, UNMOUNT_COLD_CHECK
 from daq_utils import getBlConfig, setBlConfig
+import db_lib
 
 if typing.TYPE_CHECKING:
     from lsdcGui import ControlMain
@@ -122,6 +123,8 @@ class StaffScreenDialog(QtWidgets.QFrame):
         self.homePinsButton.clicked.connect(self.homePinsCB)
         self.clearMountedSampleButton = QtWidgets.QPushButton("Clear Mounted Sample")
         self.clearMountedSampleButton.clicked.connect(self.clearMountedSampleCB)
+        self.refreshDewarListButton = QtWidgets.QPushButton("Refresh Dewar Tree")
+        self.refreshDewarListButton.clicked.connect(self.refresh_dewar_tree)
         hBoxColParams2.addWidget(self.openPort1Button)
         hBoxColParams2.addWidget(self.closePortsButton)
         hBoxColParams2.addWidget(self.unmountColdButton)
@@ -129,6 +132,7 @@ class StaffScreenDialog(QtWidgets.QFrame):
         hBoxColParams2.addWidget(self.enableTScreenButton)
         hBoxColParams2.addWidget(self.parkButton)
         hBoxColParams2.addWidget(self.clearMountedSampleButton)
+        hBoxColParams2.addWidget(self.refreshDewarListButton)
         hBoxColParams1.addWidget(self.homePinsButton)
         self.setFastDPNodesButton = QtWidgets.QPushButton("Set FastDP Nodes")
         self.setFastDPNodesButton.clicked.connect(self.setFastDPNodesCB)
@@ -208,6 +212,9 @@ class StaffScreenDialog(QtWidgets.QFrame):
         self.setLayout(vBoxColParams1)
         if show:
             self.show()
+
+    def refresh_dewar_tree(self):
+        self.parent.dewarTree.refreshTreeDewarView(get_latest_pucks=True)
 
     def getSpotNodeList(self):
         nodeList = []


### PR DESCRIPTION
Added a refresh button that allows the dewar tree to get the latest puck information that was uploaded via excel sheets.

Situations where this would be useful:
1. BL scientist uploads puck data, pucks get added to LSDC puck to dewar. If there are further changes in the puck information, the scientist uploads excel file and hits refresh to get the latest data
2. Scientist forgets to upload latest excel file before using the puck scanner. Puck scanner adds old info into LSDC. Then scientist uploads excel file followed by refresh button