### PR TITLE
Added unmount cold and end visit buttons to main panel

### DIFF
--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -21,7 +21,6 @@ from qtpy.QtCore import QModelIndex, QRectF, Qt, QTimer
 from qtpy.QtGui import QIntValidator
 from qtpy.QtWidgets import QApplication, QCheckBox, QFrame, QGraphicsPixmapItem
 
-from gui.albula.interface import AlbulaInterface
 import daq_utils
 import db_lib
 import lsdcOlog
@@ -40,6 +39,7 @@ from config_params import (
 )
 from daq_utils import getBlConfig, setBlConfig
 from element_info import element_info
+from gui.albula.interface import AlbulaInterface
 from gui.data_loc_info import DataLocInfo
 from gui.dewar_tree import DewarTree
 from gui.dialog import (
@@ -54,7 +54,6 @@ from gui.dialog import (
 from gui.raster import RasterCell, RasterGroup
 from QPeriodicTable import QPeriodicTable
 from threads import RaddoseThread, ServerCheckThread, VideoThread
-from threads import RaddoseThread, VideoThread, ServerCheckThread
 from utils import validation
 
 logger = logging.getLogger()
@@ -354,6 +353,8 @@ class ControlMain(QtWidgets.QMainWindow):
         )
         warmupButton = QtWidgets.QPushButton("Warmup Gripper")
         warmupButton.clicked.connect(self.warmupGripperCB)
+        endVisitButton = QtWidgets.QPushButton("End Visit")
+        endVisitButton.clicked.connect(self.endVisitCB)
         restartServerButton = QtWidgets.QPushButton("Restart Server")
         restartServerButton.clicked.connect(self.restartServerCB)
         self.openShutterButton = QtWidgets.QPushButton("Open Photon Shutter")
@@ -376,6 +377,7 @@ class ControlMain(QtWidgets.QMainWindow):
         vBoxTreeButtsLayoutRight.addWidget(unmountSampleButton)
         vBoxTreeButtsLayoutRight.addWidget(deQueueSelectedButton)
         vBoxTreeButtsLayoutRight.addWidget(emptyQueueButton)
+        vBoxTreeButtsLayoutRight.addWidget(endVisitButton)
         vBoxTreeButtsLayoutRight.addWidget(restartServerButton)
         hBoxTreeButtsLayout.addLayout(vBoxTreeButtsLayoutLeft)
         hBoxTreeButtsLayout.addLayout(vBoxTreeButtsLayoutRight)
@@ -4450,6 +4452,10 @@ class ControlMain(QtWidgets.QMainWindow):
 
     def unmountSampleCB(self):
         logger.info("unmount sample")
+        self.send_to_server("unmountCold")
+
+    def endVisitCB(self):
+        logger.info('Ending visit')
         self.send_to_server("unmountSample")
         
 

--- a/gui/dialog/user_screen.py
+++ b/gui/dialog/user_screen.py
@@ -54,7 +54,7 @@ class UserScreenDialog(QtWidgets.QFrame):
         robotGB.setTitle("Robot")
 
         self.unmountWarmButton = QtWidgets.QPushButton("Unmount Warm")
-        self.unmountWarmButton.clicked.connect(self.unmountSampleCB)
+        self.unmountWarmButton.clicked.connect(self.unmountWarmCB)
         self.testRobotButton = QtWidgets.QPushButton("Test Robot")
         self.testRobotButton.clicked.connect(self.testRobotCB)
         self.recoverRobotButton = QtWidgets.QPushButton("Recover Robot")
@@ -211,7 +211,7 @@ class UserScreenDialog(QtWidgets.QFrame):
     def setSlit1YCB(self):
         self.parent.send_to_server("setSlit1Y", [self.slit1YMotor_ledit.text()])
 
-    def unmountSampleCB(self):
+    def unmountWarmCB(self):
         self.parent.send_to_server("unmountSample")
 
     def testRobotCB(self):

--- a/gui/dialog/user_screen.py
+++ b/gui/dialog/user_screen.py
@@ -53,8 +53,8 @@ class UserScreenDialog(QtWidgets.QFrame):
         robotGB = QtWidgets.QGroupBox()
         robotGB.setTitle("Robot")
 
-        self.unmountColdButton = QtWidgets.QPushButton("Unmount Cold")
-        self.unmountColdButton.clicked.connect(self.unmountColdCB)
+        self.unmountWarmButton = QtWidgets.QPushButton("Unmount Warm")
+        self.unmountWarmButton.clicked.connect(self.unmountSampleCB)
         self.testRobotButton = QtWidgets.QPushButton("Test Robot")
         self.testRobotButton.clicked.connect(self.testRobotCB)
         self.recoverRobotButton = QtWidgets.QPushButton("Recover Robot")
@@ -67,7 +67,7 @@ class UserScreenDialog(QtWidgets.QFrame):
         self.checkQueueCollect()
         self.queueCollectOnCheckBox.stateChanged.connect(self.queueCollectOnCheckCB)
 
-        hBoxColParams3.addWidget(self.unmountColdButton)
+        hBoxColParams3.addWidget(self.unmountWarmButton)
         hBoxColParams3.addWidget(self.testRobotButton)
         hBoxColParams3.addWidget(self.recoverRobotButton)
         hBoxColParams3.addWidget(self.dryGripperButton)
@@ -181,7 +181,7 @@ class UserScreenDialog(QtWidgets.QFrame):
 
         if daq_utils.beamline == "nyx":
             self.openShutterButton.setDisabled(True)
-            self.unmountColdButton.setDisabled(True)
+            self.unmountWarmButton.setDisabled(True)
             self.testRobotButton.setDisabled(True)
             self.recoverRobotButton.setDisabled(True)
             self.dryGripperButton.setDisabled(True)
@@ -211,8 +211,8 @@ class UserScreenDialog(QtWidgets.QFrame):
     def setSlit1YCB(self):
         self.parent.send_to_server("setSlit1Y", [self.slit1YMotor_ledit.text()])
 
-    def unmountColdCB(self):
-        self.parent.send_to_server("unmountCold")
+    def unmountSampleCB(self):
+        self.parent.send_to_server("unmountSample")
 
     def testRobotCB(self):
         self.parent.send_to_server("testRobot")


### PR DESCRIPTION
Was asked by AMX and FMX last cycle to move unmount cold to button panel from user screen because users click unmount and have to wait a long time to warm up and cool down. Instead we have end visit button that will unmount and warm up.

This button will be hopefully used in the future where use it to indicate they have finished. We can potentially automatically kick off queued auto collections thereby using all the photons