### PR TITLE
Added default text for raster step

### DIFF
--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -723,6 +723,7 @@ class ControlMain(QtWidgets.QMainWindow):
         self.rasterStepEdit = QtWidgets.QLineEdit(str(self.rasterStepDefs["Coarse"]))
         self.rasterStepEdit.textChanged[str].connect(self.rasterStepChanged)
         self.rasterStepEdit.setFixedWidth(60)
+        self.rasterStepEdit.setText("20")
         self.rasterGrainRadioGroup = QtWidgets.QButtonGroup()
         self.rasterGrainCoarseRadio = QtWidgets.QRadioButton("Coarse")
         self.rasterGrainCoarseRadio.setChecked(False)


### PR DESCRIPTION
Added a default value for raster step since if you add any other collection at startup, LSDC will complain that not all parameters are filled even though the added collection has nothing to do with rasters