### PR TITLE
Moving omega is done by server and only in SA

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -86,6 +86,14 @@ def abortBS():
     except super_state_machine.errors.TransitionError:
       logger.error("caught BS")
 
+def move_omega(omega, relative=True):
+  """Moves omega by a certain amount"""
+  if gov_robot.state.get() == "SA":
+    if relative:
+      RE(bps.mvr(samplexyz.omega, omega))
+    else:
+      RE(bps.mv(samplexyz.omega, omega))
+
 def changeImageCenterLowMag(x,y,czoom):
   zoom = int(czoom)
   zoomMinXRBV = getPvDesc("lowMagZoomMinXRBV")

--- a/daq_main_common.py
+++ b/daq_main_common.py
@@ -75,7 +75,8 @@ functions = [anneal,
   setSlit1X,
   setSlit1Y,
   testRobot,
-  setGovState]
+  setGovState,
+  move_omega]
 
 whitelisted_functions: "Dict[str, Callable]" = {
     func.__name__: func for func in functions

--- a/gui/control_main.py
+++ b/gui/control_main.py
@@ -2688,8 +2688,9 @@ class ControlMain(QtWidgets.QMainWindow):
 
     def moveOmegaCB(self):
         self.send_to_server(
-            "mvaDescriptor",
-            ["omega", float(self.sampleOmegaMoveLedit.getEntry().text())],
+            "move_omega",
+            [float(self.sampleOmegaMoveLedit.getEntry().text())],
+            {"relative": False}
         )
 
     def moveEnergyCB(self):
@@ -2780,16 +2781,15 @@ class ControlMain(QtWidgets.QMainWindow):
 
     def omegaTweakNegCB(self):
         tv = float(self.omegaTweakVal_ledit.text())
-        tweakVal = 0.0 - tv
         if self.controlEnabled():
-            self.omegaTweak_pv.put(tweakVal)
+            self.send_to_server("move_omega", [-tv])
         else:
             self.popupServerMessage("You don't have control")
 
     def omegaTweakPosCB(self):
         tv = float(self.omegaTweakVal_ledit.text())
         if self.controlEnabled():
-            self.omegaTweak_pv.put(tv)
+            self.send_to_server("move_omega", [tv])
         else:
             self.popupServerMessage("You don't have control")
 
@@ -2824,9 +2824,8 @@ class ControlMain(QtWidgets.QMainWindow):
             self.popupServerMessage("You don't have control")
 
     def omegaTweakCB(self, tv):
-        tvf = float(tv)
         if self.controlEnabled():
-            self.omegaTweak_pv.put(tvf)
+            self.send_to_server("move_omega", [float(tv)])
             time.sleep(0.05)
         else:
             self.popupServerMessage("You don't have control")


### PR DESCRIPTION
Users tend to move omega before the sample finishes alignment. This moves the governor into M state.

This PR, removes the poking of the omega directly from the GUI. The server moves omega using bluesky and only in SA state