### PR TITLE
Startup checks don't happen during monitor handling

### DIFF
--- a/gui/albula/controller.py
+++ b/gui/albula/controller.py
@@ -71,7 +71,6 @@ class AlbulaController:
 
     def handle_monitor(self, char_value, **kwargs):
         if char_value == GovState.DA.value:
-            self.startup()
             self._stop.clear()
             self.imageDaemon = threading.Thread(target=self.update_image, args=())
             if not self.imageDaemon.is_alive():
@@ -122,7 +121,6 @@ class AlbulaController:
         """
         Run an endless loop, stopped by keyboard interrupt or exception
         """
-        self.startup()
 
         while not self._stop.is_set():
             try:


### PR DESCRIPTION
Occasionally when LSDC starts up, there are 2 subFrames that open within Albula

This happens if there is a collection running during LSDC GUI start up. Its because in "monitor mode" LSDC checks if there is a subFrame already open, if not it will open a new one. During initialization albula is in a weird state such that it tells LSDC that there is no subframe open (even though there is one) so it opens 2 subframes. 

This change removes the check to see if there is a subframe, and fixes the problem