### PR TITLE
enable use of alternative ISPyB config files

### DIFF
--- a/ispybLib.py
+++ b/ispybLib.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 #12/19 - I'm leaving all commented lines alone on this. Karl Levik, DLS, is an immense help with this.
 
-conf_file = "/etc/ispyb/ispybConfig.cfg"
+ispyb_db_name = os.environ("ISPYB_DB", "ispyb")
+conf_file = f"/etc/ispyb/{ispyb_db_name}Config.cfg"
 visit = 'mx99999-1'
 # Get a list of request dicts
 #request_dicts = lsdb2.getColRequestsByTimeInterval('2018-02-14T00:00:00','2018-02-15T00:00:00')


### PR DESCRIPTION
 * use ISPYB_DB environment variable to enable use of a different ISPyB config file, such as for use of the ispyb-dev database
 * this will allow, for example, to test LSDC code that populates ISPyB by simply changing the ISPYB_DB env var
 * see https://github.com/NSLS2/ansible/pull/2084 for the Ansible role that sets the environment variable to determine the database used when calling this script