### PR TITLE
Robot recovery procedure during automated collection for EMBL robot

### DIFF
--- a/daq_macros.py
+++ b/daq_macros.py
@@ -19,6 +19,7 @@ import _thread
 import parseSheet
 import attenCalc
 import raddoseLib
+import robot_lib
 from raddoseLib import *
 import logging
 logger = logging.getLogger(__name__)
@@ -248,6 +249,15 @@ sample_detection = {
   "face_on_omega" : 0
 }
 
+def run_robot_recovery_procedure():
+  """ Generic recovery procedure to be used during automated
+  collection"""
+  # Recover robot
+  robot_lib.recoverRobot()
+  # Dry Gripper
+  robot_lib.dryGripper()
+  # Park Gripper and cool gripper
+  robot_lib.cooldownGripper()
 
 def run_top_view_optimized():
     RE(topview_optimized())

--- a/embl_robot.py
+++ b/embl_robot.py
@@ -459,6 +459,7 @@ class EMBLRobot:
                 RobotControlLib.unmount2(absPos)
               except Exception as e:
                 # If there is an exception again, return UNMOUNT_FAILURE
+                daq_macros.run_robot_recovery_procedure()
                 e_s = str(e)
                 message = "ROBOT unmount2 ERROR: " + e_s
                 daq_lib.gui_message(message)

--- a/embl_robot.py
+++ b/embl_robot.py
@@ -451,7 +451,7 @@ class EMBLRobot:
               daq_macros.disableMount()
               daq_lib.gui_message(e_s + ". FATAL ROBOT ERROR - CALL STAFF! robotOff() executed.")
               return UNMOUNT_FAILURE
-            elif (e_s.find("SE") != -1):
+            elif "SE" in e_s:
               # In case there is an SE Timeout error, run the recovery procedure
               daq_macros.run_robot_recovery_procedure()
               try:
@@ -460,8 +460,7 @@ class EMBLRobot:
               except Exception as e:
                 # If there is an exception again, return UNMOUNT_FAILURE
                 daq_macros.run_robot_recovery_procedure()
-                e_s = str(e)
-                message = "ROBOT unmount2 ERROR: " + e_s
+                message = f"ROBOT unmount2 ERROR: {e}"
                 daq_lib.gui_message(message)
                 logger.error(message)
                 return UNMOUNT_FAILURE

--- a/robot_lib.py
+++ b/robot_lib.py
@@ -133,3 +133,6 @@ def openGripper():
 
 def closeGripper():
     robot.closeGripper()
+
+def cooldownGripper():
+  robot.cooldownGripper()


### PR DESCRIPTION
There have been multiple cases where during automated collection, the robot starts the unmounting procedure. Just before the robot gripper picks up the sample, it waits for the governor to get into SE state. If it does not reach SE (a common case being the piny or pinz not moving, additionally the GovMon not recovering from the error in time). 

In this case the gripper stays at the unmount position indefinitely. This PR detects the SE timeout error and runs a robot recovery macro, which includes:
1. Recovering robot
2. Drying gripper
3. Park and cool gripper
After the recovery procedure, it will attempt to unmount again (by this time GovMon should have done its magic) and continue the automated collection. 
If the second attempt fails as well, the recovery macro is run and the user is informed and automated collection is stopped